### PR TITLE
Fix client/server resfile list mismatching on connect

### DIFF
--- a/source/engine/client/m_misc.cpp
+++ b/source/engine/client/m_misc.cpp
@@ -237,15 +237,15 @@ std::string M_ExpandTokens(const std::string &str)
             break;
         }
         case 'w':
-            if (wadfiles.size() == 2)
+            if (wadfiles.size() == 1)
             {
                 // We're playing an IWAD map
-                buffer << wadfiles[1].getBasename();
+                buffer << wadfiles[0].getBasename();
             }
-            else if (wadfiles.size() > 2)
+            else if (wadfiles.size() > 1)
             {
                 // We're playing a PWAD map
-                buffer << wadfiles[2].getBasename();
+                buffer << wadfiles[1].getBasename();
             }
             break;
         case 'm':

--- a/source/engine/common/d_main.cpp
+++ b/source/engine/common/d_main.cpp
@@ -274,16 +274,34 @@ static bool CheckWantedMatchesLoaded(const OWantFiles &newwadfiles)
 {
     // Cheking sizes is a good first approximation.
 
-    if (newwadfiles.size() + 1 != ::wadfiles.size())
+    if (newwadfiles.size() != ::wadfiles.size())
     {
         return false;
     }
 
-    // Check WAD hashes
-    for (OWantFiles::const_iterator it = newwadfiles.begin(); it != newwadfiles.end(); ++it)
+    for (size_t idx = 0; idx < ::wadfiles.size(); idx++)
     {
-        size_t idx = it - newwadfiles.begin();
-        if (it->getWantedMD5() != ::wadfiles.at(idx).getMD5())
+        const OMD5Hash &wadfilehash = ::wadfiles.at(idx).getMD5();
+        const OMD5Hash &newfilehash = newwadfiles.at(idx).getWantedMD5();
+        // Wadfile hash empty? If the existing wadfile is a path 
+        // just check basenames for equality and hope they have the same content for now - Dasho
+        if (wadfilehash.empty())
+        {
+            if (::wadfiles.at(idx).getType() != OFILE_FOLDER)
+                return false;
+            else if (!newfilehash.empty()) // should be empty if also a path
+                return false;
+            else if (::wadfiles.at(idx).getBasename() != newwadfiles.at(idx).getBasename())
+                return false;
+        }
+        // Don't think our "wanted files" do any MD5 stuff yet, so if the wanted file hash is empty
+        // just check basenames - Dasho
+        else if (newfilehash.empty())
+        {
+            if (::wadfiles.at(idx).getBasename() != newwadfiles.at(idx).getBasename())
+                return false;
+        }
+        else if (wadfilehash != newfilehash)
         {
             return false;
         }

--- a/source/engine/common/g_level.cpp
+++ b/source/engine/common/g_level.cpp
@@ -289,7 +289,7 @@ bool G_LoadWad(const OWantFiles &newwadfiles, const std::string &mapname)
     // Did we switch IWAD files?
     if (AddedIWAD && !::wadfiles.empty())
     {
-        if (newwadfiles.at(0).getBasename() != wadfiles.at(1).getBasename())
+        if (newwadfiles.at(0).getBasename() != wadfiles.at(0).getBasename())
         {
             Reboot = true;
         }
@@ -298,7 +298,7 @@ bool G_LoadWad(const OWantFiles &newwadfiles, const std::string &mapname)
     // Do the sizes of the WAD lists not match up?
     if (!Reboot)
     {
-        if (::wadfiles.size() - 2 != newwadfiles.size() - (AddedIWAD ? 1 : 0))
+        if (::wadfiles.size() != newwadfiles.size())
         {
             Reboot = true;
         }
@@ -307,9 +307,9 @@ bool G_LoadWad(const OWantFiles &newwadfiles, const std::string &mapname)
     // Do our WAD lists match up exactly?
     if (!Reboot)
     {
-        for (size_t i = 2, j = (AddedIWAD ? 1 : 0); i < ::wadfiles.size() && j < newwadfiles.size(); i++, j++)
+        for (size_t i = 0; i < ::wadfiles.size() && i < newwadfiles.size(); i++)
         {
-            if (!(newwadfiles.at(j).getBasename() == ::wadfiles.at(i).getBasename()))
+            if (!(newwadfiles.at(i).getBasename() == ::wadfiles.at(i).getBasename()))
             {
                 Reboot = true;
                 break;

--- a/source/engine/server/sv_sqpold.cpp
+++ b/source/engine/server/sv_sqpold.cpp
@@ -163,9 +163,9 @@ void SV_SendServerInfo()
     if (numwads > 0xff)
         numwads = 0xff;
 
-    MSG_WriteByte(&ml_message, numwads - 1);
+    MSG_WriteByte(&ml_message, numwads);
 
-    for (i = 1; i < numwads; ++i)
+    for (i = 0; i < numwads; ++i)
         MSG_WriteString(&ml_message, wadfiles[i].getBasename().c_str());
 
     MSG_WriteBool(&ml_message, (sv_gametype == GM_DM || sv_gametype == GM_TEAMDM));


### PR DESCRIPTION
This may evolve as time goes on, but for now we are doing a straight comparison of all files loaded, to include the IWAD in use. There were some leftover assumptions from when odamex.wad existed and was always the first file in the load order.