### PR TITLE
Texture Manager format/tweak pass

### DIFF
--- a/source/engine/common/res_texture.cpp
+++ b/source/engine/common/res_texture.cpp
@@ -46,6 +46,8 @@
 #include "v_video.h"
 #include "w_wad.h"
 
+static constexpr uint16_t column_end = 0xFFFF;
+
 // patch conversion structs
 struct texpost_t
 {
@@ -186,7 +188,7 @@ void Texture::init(int32_t width, int32_t height)
     mScaleX    = FRACUNIT;
     mScaleY    = FRACUNIT;
     mData      = NULL;
-    mARGBData  = NULL;    
+    mARGBData  = NULL;
 }
 
 // ============================================================================
@@ -758,13 +760,14 @@ void TextureManager::generateNotFoundTexture()
 // Allocates memory for a new texture and returns a pointer to it. The texture
 // is inserted into mHandlesMap for future retrieval.
 //
-Texture *TextureManager::createTexture(texhandle_t texhandle, Texture::TextureSourceType type, int32_t width, int32_t height)
+Texture *TextureManager::createTexture(texhandle_t texhandle, Texture::TextureSourceType type, int32_t width,
+                                       int32_t height)
 {
     width  = std::min<int32_t>(width, Texture::MAX_TEXTURE_WIDTH);
     height = std::min<int32_t>(height, Texture::MAX_TEXTURE_HEIGHT);
 
     Texture *texture = new Texture;
-    texture->mType = type;
+    texture->mType   = type;
     texture->init(width, height);
 
     texture->mHandle = texhandle;
@@ -856,7 +859,7 @@ void TextureManager::cacheSprite(texhandle_t handle)
 
     if (!clientside)
     {
-        Texture *texture = createTexture(handle,  Texture::TextureSourceType::TEX_SPRITE, width, height);
+        Texture *texture = createTexture(handle, Texture::TextureSourceType::TEX_SPRITE, width, height);
         delete[] filedata;
         PHYSFS_close(rawsprite);
     }
@@ -873,8 +876,8 @@ void TextureManager::cacheSprite(texhandle_t handle)
 
         V_DynamicPaletteAddImage(decoded_img, width, height);
 
-        Texture *texture  = createTexture(handle, Texture::TextureSourceType::TEX_SPRITE, width, height);
-        
+        Texture *texture = createTexture(handle, Texture::TextureSourceType::TEX_SPRITE, width, height);
+
         // temporary PNG grAb chunk check
         int32_t i = 0;
         int32_t j = 0;
@@ -1014,7 +1017,7 @@ void TextureManager::remapTextures()
                 }
                 else
                 {
-                    generateColumns(it->second);                    
+                    generateColumns(it->second);
                 }
             }
         }
@@ -1039,8 +1042,9 @@ void TextureManager::remapFlat(Texture *texture)
         return;
     }
 
-    int32_t  bpp        = 4;
-    uint32_t pixel_step = width * bpp;
+    int32_t       bpp             = 4;
+    uint32_t      pixel_step      = width * bpp;
+    const argb_t *current_palette = V_GetDefaultPalette()->basecolors;
 
     if (texture->mData)
     {
@@ -1057,10 +1061,10 @@ void TextureManager::remapFlat(Texture *texture)
 
         for (uint32_t y = 0; y < height; y++)
         {
-            argb_t color(bpp == 4 ? *(pixel + 3) : 255, *pixel, *(pixel + 1), *(pixel + 2));
+            uint8_t alpha = *(pixel + 3);
 
-            if (color.geta() != 0)
-                *dest = V_BestColor(V_GetDefaultPalette()->basecolors, color);
+            if (alpha != 0)
+                *dest = V_BestColor(current_palette, {alpha, *pixel, *(pixel + 1), *(pixel + 2)});
 
             dest += width;
             pixel += pixel_step;
@@ -1097,9 +1101,10 @@ void TextureManager::generateColumns(Texture *texture)
         I_FatalError("TextureManager::generateColumns - no raw image data");
     }
 
-    int32_t width  = texture->getWidth();
-    int32_t height = texture->getHeight();
-    int32_t bpp    = 4;
+    int32_t       width           = texture->getWidth();
+    int32_t       height          = texture->getHeight();
+    int32_t       bpp             = 4;
+    const argb_t *current_palette = V_GetDefaultPalette()->basecolors;
 
     if (texture->mData)
     {
@@ -1111,7 +1116,6 @@ void TextureManager::generateColumns(Texture *texture)
     int32_t                  pixel_step = bpp * width;
 
     // Go through columns
-    uint32_t offset = 0;
     for (int32_t c = 0; c < width; c++)
     {
         texcolumn_t col;
@@ -1120,29 +1124,13 @@ void TextureManager::generateColumns(Texture *texture)
         bool     ispost = false;
         uint8_t *pixel  = texture->mARGBData + c * bpp;
 
-        offset          = c;
         uint8_t row_off = 0;
         for (int32_t r = 0; r < height; r++)
         {
-            // For vanilla-compatible dimensions, use a split at 128 to prevent tiling.
-            if (height < 256)
-            {
-                if (row_off == 128)
-                {
-                    // Finish current post if any
-                    if (ispost)
-                    {
-                        col.posts.push_back(post);
-                        post.pixels.clear();
-                        ispost = false;
-                    }
-                }
-            }
-
-            argb_t color(bpp == 4 ? *(pixel + 3) : 255, *pixel, *(pixel + 1), *(pixel + 2));
+            uint8_t alpha = *(pixel + 3);
 
             // If the current pixel is not transparent, add it to the current post
-            if (color.geta() != 0)
+            if (alpha != 0)
             {
                 // If we're not currently building a post, begin one and set its offset
                 if (!ispost)
@@ -1155,7 +1143,7 @@ void TextureManager::generateColumns(Texture *texture)
                 }
 
                 // Add the pixel to the post
-                post.pixels.push_back(V_BestColor(V_GetDefaultPalette()->basecolors, color));
+                post.pixels.push_back(V_BestColor(current_palette, {alpha, *pixel, *(pixel + 1), *(pixel + 2)}));
             }
             else if (ispost)
             {
@@ -1167,7 +1155,6 @@ void TextureManager::generateColumns(Texture *texture)
             }
 
             // Go to next row
-            offset += width;
             pixel += pixel_step;
             row_off++;
         }
@@ -1178,9 +1165,6 @@ void TextureManager::generateColumns(Texture *texture)
 
         // Add the column data
         columns.push_back(col);
-
-        // Go to next column
-        offset++;
     }
 
     // Write doom gfx data to output
@@ -1223,8 +1207,7 @@ void TextureManager::generateColumns(Texture *texture)
         }
 
         // Write 0xFFFF row to signal end of column
-        uint16_t temp = 0xFFFF;
-        mem_fwrite(&temp, sizeof(uint16_t), 1, newpatch);
+        mem_fwrite(&column_end, 2, 1, newpatch);
     }
 
     // Now we write column offsets
@@ -1292,7 +1275,7 @@ void TextureManager::cacheTexture(texhandle_t handle)
 
         V_DynamicPaletteAddImage(decoded_img, width, height);
 
-        Texture *texture  = createTexture(handle, Texture::TextureSourceType::TEX_TEXTURE, width, height);
+        Texture *texture = createTexture(handle, Texture::TextureSourceType::TEX_TEXTURE, width, height);
 
         // temporary PNG grAb chunk check
         int32_t i = 0;

--- a/source/engine/common/res_texture.h
+++ b/source/engine/common/res_texture.h
@@ -143,7 +143,7 @@ class Texture
 
     Texture();
 
-    void          init(int32_t width, int32_t height);
+    void init(int32_t width, int32_t height);
 
     texhandle_t mHandle;
 
@@ -159,8 +159,8 @@ class Texture
     int16_t mOffsetX;
     int16_t mOffsetY;
 
-    uint8_t	mWidthBits;
-	uint8_t	mHeightBits;
+    uint8_t mWidthBits;
+    uint8_t mHeightBits;
 
     TextureSourceType mType;
 
@@ -210,14 +210,14 @@ class TextureManager
 
     void remapTextures();
     void invalidateTextureMapping();
-    
+
     static const texhandle_t NO_TEXTURE_HANDLE        = 0x0;
     static const texhandle_t NOT_FOUND_TEXTURE_HANDLE = 0x1;
 
   private:
-    static const uint32_t FLAT_HANDLE_MASK        = 0x00020000ul;
-    static const uint32_t SPRITE_HANDLE_MASK      = 0x00040000ul;
-    static const uint32_t TEXTURE_HANDLE_MASK     = 0x00080000ul;
+    static const uint32_t FLAT_HANDLE_MASK    = 0x00020000ul;
+    static const uint32_t SPRITE_HANDLE_MASK  = 0x00040000ul;
+    static const uint32_t TEXTURE_HANDLE_MASK = 0x00080000ul;
 
     // initialization routines
     void clear();
@@ -226,29 +226,29 @@ class TextureManager
     void readAnimDefLump();
     void readAnimatedLump();
 
-    void remapFlat(Texture* texture);
-    void generateColumns(Texture* texture);
+    void remapFlat(Texture *texture);
+    void generateColumns(Texture *texture);
 
     // sprites
-    texhandle_t getSpriteHandle(const OString &name);
-    void        cacheSprite(texhandle_t handle);
+    texhandle_t                           getSpriteHandle(const OString &name);
+    void                                  cacheSprite(texhandle_t handle);
     typedef OHashTable<OString, uint32_t> EnumeratedSpriteMap;
-    EnumeratedSpriteMap                       mEnumeratedSpriteMap;
-    std::vector<std::string>                  mSpriteFilenames;
+    EnumeratedSpriteMap                   mEnumeratedSpriteMap;
+    std::vector<std::string>              mSpriteFilenames;
 
     // flats
-    texhandle_t getFlatHandle(const OString &name);
-    void        cacheFlat(texhandle_t handle);
+    texhandle_t                           getFlatHandle(const OString &name);
+    void                                  cacheFlat(texhandle_t handle);
     typedef OHashTable<OString, uint32_t> EnumeratedFlatMap;
-    EnumeratedFlatMap                         mEnumeratedFlatMap;
-    std::vector<std::string>                  mFlatFilenames;
+    EnumeratedFlatMap                     mEnumeratedFlatMap;
+    std::vector<std::string>              mFlatFilenames;
 
     // wall textures
-    texhandle_t getTextureHandle(const OString &name);
-    void        cacheTexture(texhandle_t handle);
+    texhandle_t                           getTextureHandle(const OString &name);
+    void                                  cacheTexture(texhandle_t handle);
     typedef OHashTable<OString, uint32_t> EnumeratedTextureMap;
-    EnumeratedTextureMap                      mEnumeratedTextureMap;
-    std::vector<std::string>                  mTextureFilenames;
+    EnumeratedTextureMap                  mEnumeratedTextureMap;
+    std::vector<std::string>              mTextureFilenames;
 
     // maps texture handles to Texture*
     typedef OHashTable<texhandle_t, Texture *> HandleMap;
@@ -259,13 +259,13 @@ class TextureManager
     struct anim_t
     {
         static const uint32_t MAX_ANIM_FRAMES = 32;
-        texhandle_t               basepic;
-        int16_t                     numframes;
-        uint8_t                      countdown;
-        uint8_t                      curframe;
-        uint8_t                      speedmin[MAX_ANIM_FRAMES];
-        uint8_t                      speedmax[MAX_ANIM_FRAMES];
-        texhandle_t               framepic[MAX_ANIM_FRAMES];
+        texhandle_t           basepic;
+        int16_t               numframes;
+        uint8_t               countdown;
+        uint8_t               curframe;
+        uint8_t               speedmin[MAX_ANIM_FRAMES];
+        uint8_t               speedmax[MAX_ANIM_FRAMES];
+        texhandle_t           framepic[MAX_ANIM_FRAMES];
     };
 
     std::vector<anim_t> mAnimDefs;


### PR DESCRIPTION
Did a quick format pass with our clang format file; also tried to speed up a couple of loops by not, for instance, continually looking up the default palette and only creating a full argb_t when the alpha is > 0 versus creating an argb_t and then using its geta() method.

The splitting of textures less than 256 pixels tall at row 128 I believe is no longer needed since we are directly converting to tallposts