### PR TITLE
Define UNICODE on Windows and update some functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 vcpkg_installed
 .vscode/settings.json
+.vscode/cmake-kits.json
 *.pdb
 *.exe
 *.WAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,26 +38,30 @@ if (MUD_PROFILING)
   add_definitions(-DMUD_PROFILING -DTRACY_ENABLE -DTRACY_CALLSTACK)
 endif()
 
-if (WIN32 AND NOT MINGW)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")    
-    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>")
-    
-    if (NOT CLANG)
+if (WIN32)
+
+    add_compile_definitions(UNICODE)
+
+    if (MSVC)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")    
+        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>")
+        
         # get the number of logical cores for parallel build
         cmake_host_system_information(RESULT LOGICAL_CORES QUERY NUMBER_OF_LOGICAL_CORES)
         math(EXPR COMPILE_CORES "${LOGICAL_CORES} - 1")  
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP${COMPILE_CORES}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP${COMPILE_CORES}")
+
+        # Disable some very noisy warnings from the MSVC build
+        # CRT security and POSIX deprecation warnings
+        add_definitions("-D_CRT_SECURE_NO_WARNINGS /wd4996")
+        # Loss of precision/data on assignment, requires lots of explicit casting
+        add_definitions("/wd4244 /wd4267")
+        # Unreferenced formal parameter, and there are many of these
+        add_definitions("/wd4100")
     endif()
 
-    # Disable some very noisy warnings from the MSVC build
-    # CRT security and POSIX deprecation warnings
-    add_definitions("-D_CRT_SECURE_NO_WARNINGS /wd4996")
-    # Loss of precision/data on assignment, requires lots of explicit casting
-    add_definitions("/wd4244 /wd4267")
-    # Unreferenced formal parameter, and there are many of these
-    add_definitions("/wd4100")
-elseif(NOT MINGW)
+else()
 
     add_definitions(-DUNIX)
     

--- a/source/engine/client/sdl/i_main.cpp
+++ b/source/engine/client/sdl/i_main.cpp
@@ -146,17 +146,6 @@ int32_t main(int32_t argc, char *argv[])
             exit(EXIT_SUCCESS);
         }
 
-        const char *crashdir = ::Args.CheckValue("-crashdir");
-        if (crashdir)
-        {
-            I_SetCrashDir(crashdir);
-        }
-        else
-        {
-            std::string writedir = M_GetWriteDir();
-            I_SetCrashDir(writedir.c_str());
-        }
-
         const char *CON_FILE = ::Args.CheckValue("-confile");
         if (CON_FILE)
         {

--- a/source/engine/client/sdl/i_system.cpp
+++ b/source/engine/client/sdl/i_system.cpp
@@ -337,7 +337,6 @@ void SetLanguageIDs()
                 LanguageIDs[2] = lang;
                 LanguageIDs[3] = lang;
             }
-            SDL_free(pref_langs);
         }
         else  // Default (English)
         {
@@ -347,6 +346,8 @@ void SetLanguageIDs()
             LanguageIDs[2] = lang;
             LanguageIDs[3] = lang;
         }
+        if (pref_langs)
+            SDL_free(pref_langs);
     }
     else
     {

--- a/source/engine/client/sdl/i_system.cpp
+++ b/source/engine/client/sdl/i_system.cpp
@@ -299,30 +299,6 @@ void I_WaitVBL(int32_t count)
     I_Sleep(1000000LL * 1000LL * count / 70);
 }
 
-//
-// SubsetLanguageIDs
-//
-#if defined _WIN32
-static void SubsetLanguageIDs(LCID id, LCTYPE type, int32_t idx)
-{
-    char  buf[8];
-    LCID  langid;
-    char *idp;
-
-    if (!GetLocaleInfo(id, type, buf, 8))
-        return;
-    langid = MAKELCID(strtoul(buf, NULL, 16), SORT_DEFAULT);
-    if (!GetLocaleInfo(langid, LOCALE_SABBREVLANGNAME, buf, 8))
-        return;
-    idp = (char *)(&LanguageIDs[idx]);
-    memset(idp, 0, 4);
-    idp[0] = tolower(buf[0]);
-    idp[1] = tolower(buf[1]);
-    idp[2] = tolower(buf[2]);
-    idp[3] = 0;
-}
-#endif
-
 EXTERN_CVAR(language)
 
 void SetLanguageIDs()
@@ -331,23 +307,52 @@ void SetLanguageIDs()
 
     if (strcmp(langid, "auto") == 0)
     {
-#if defined _WIN32
-        memset(LanguageIDs, 0, sizeof(LanguageIDs));
-        SubsetLanguageIDs(LOCALE_USER_DEFAULT, LOCALE_ILANGUAGE, 0);
-        SubsetLanguageIDs(LOCALE_USER_DEFAULT, LOCALE_IDEFAULTLANGUAGE, 1);
-        SubsetLanguageIDs(LOCALE_SYSTEM_DEFAULT, LOCALE_ILANGUAGE, 2);
-        SubsetLanguageIDs(LOCALE_SYSTEM_DEFAULT, LOCALE_IDEFAULTLANGUAGE, 3);
-#else
-        // Default to US English on non-windows systems
-        // FIXME: Use SDL Locale support if available.
-        langid = "enu";
-#endif
+        // Just set the first preferred language. Is there a use case
+        // for doing anything else right now? - Dasho
+        SDL_Locale *pref_langs = SDL_GetPreferredLocales();
+        if (pref_langs && pref_langs->language != NULL) // NULL language means end of array; country is optional
+        {
+            size_t length = strlen(pref_langs->language);
+            if (length >= 3)
+            {
+                uint32_t lang = MAKE_ID(tolower(pref_langs->language[0]), tolower(pref_langs->language[1]), tolower(pref_langs->language[2]), '\0');
+                LanguageIDs[0] = lang;
+                LanguageIDs[1] = lang;
+                LanguageIDs[2] = lang;
+                LanguageIDs[3] = lang;
+            }
+            else if (pref_langs->country != NULL)
+            {
+                uint32_t lang = MAKE_ID(tolower(pref_langs->language[0]), tolower(pref_langs->language[1]), tolower(pref_langs->country[0]), '\0');
+                LanguageIDs[0] = lang;
+                LanguageIDs[1] = lang;
+                LanguageIDs[2] = lang;
+                LanguageIDs[3] = lang;
+            }
+            else
+            {
+                uint32_t lang = MAKE_ID(tolower(pref_langs->language[0]), tolower(pref_langs->language[1]), '\0', '\0');
+                LanguageIDs[0] = lang;
+                LanguageIDs[1] = lang;
+                LanguageIDs[2] = lang;
+                LanguageIDs[3] = lang;
+            }
+            SDL_free(pref_langs);
+        }
+        else  // Default (English)
+        {
+            uint32_t lang  = MAKE_ID('*', '*', '\0', '\0');
+            LanguageIDs[0] = lang;
+            LanguageIDs[1] = lang;
+            LanguageIDs[2] = lang;
+            LanguageIDs[3] = lang;
+        }
     }
     else
     {
         char slang[4] = {'\0', '\0', '\0', '\0'};
         strncpy(slang, langid, ARRAY_LENGTH(slang) - 1);
-        uint32_t lang  = MAKE_ID(slang[0], slang[1], slang[2], slang[3]);
+        uint32_t lang  = MAKE_ID(tolower(slang[0]), tolower(slang[1]), tolower(slang[2]), tolower(slang[3]));
         LanguageIDs[0] = lang;
         LanguageIDs[1] = lang;
         LanguageIDs[2] = lang;

--- a/source/engine/common/i_crash.h
+++ b/source/engine/common/i_crash.h
@@ -25,4 +25,3 @@
 #pragma once
 
 void I_SetCrashCallbacks();
-void I_SetCrashDir(const char *crashdir);

--- a/source/engine/common/i_crash_noop.cpp
+++ b/source/engine/common/i_crash_noop.cpp
@@ -34,9 +34,4 @@ void I_SetCrashCallbacks()
     // Not implemented.
 }
 
-void I_SetCrashDir(const char *crashdir)
-{
-    // Not implemented.
-}
-
 #endif

--- a/source/engine/common/i_crash_posix.cpp
+++ b/source/engine/common/i_crash_posix.cpp
@@ -24,8 +24,6 @@
 
 #if defined UNIX && defined HAVE_BACKTRACE
 
-#define CRASH_DIR_LEN 1024
-
 #include <execinfo.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -35,11 +33,6 @@
 #include "i_crash.h"
 #include "i_system.h"
 #include "mud_includes.h"
-
-/**
- * @brief An array containing the directory where crashes are written to.
- */
-static char gCrashDir[CRASH_DIR_LEN];
 
 // Write a backtrace to a file.
 //
@@ -57,15 +50,8 @@ static void WriteBacktrace(int32_t sig, siginfo_t *si)
     strftime(timebuf, ARRAY_LENGTH(timebuf), "%Y%m%dT%H%M%S", local);
 
     // Find the spot to write our backtrace.
-    int32_t  len = 0;
-    char filename[CRASH_DIR_LEN];
-    len = snprintf(filename, ARRAY_LENGTH(filename), "%s/%s_g%s_%d_%s_dump.txt", ::gCrashDir, GAMEEXE, GitShortHash(),
-                   getpid(), timebuf);
-    if (len < 0)
-    {
-        fprintf(stderr, "%s: File path too long.\n", __FUNCTION__);
-        return;
-    }
+    const char  *filename = StrFormat("%s/%s_g%s_%d_%s_dump.txt", M_GetWriteDir().c_str(), GAMEEXE, GitShortHash(),
+                   getpid(), timebuf).c_str();
 
     // Create a file.
     int32_t fd = creat(filename, 0644);
@@ -142,37 +128,6 @@ void I_SetCrashCallbacks()
     sigaction(SIGFPE, &act, NULL);
     sigaction(SIGSEGV, &act, NULL);
     sigaction(SIGBUS, &act, NULL);
-}
-
-void I_SetCrashDir(const char *crashdir)
-{
-    std::string homedir;
-    char        testfile[CRASH_DIR_LEN];
-
-    // Check to see if our crash dir is too big.
-    size_t len = strlen(crashdir);
-    if (len > CRASH_DIR_LEN)
-    {
-        I_FatalError("Crash directory \"%s\" is too long.  Please pass a correct -crashout param.", crashdir);
-        abort();
-    }
-
-    // Check to see if we can write to our crash directory.
-    snprintf(testfile, ARRAY_LENGTH(testfile), "%s/crashXXXXXX", crashdir);
-    int32_t res = mkstemp(testfile);
-    if (res == -1)
-    {
-        I_FatalError("Crash directory \"%s\" is not writable.  Please point -crashout to "
-                     "a directory with write permissions.",
-                     crashdir);
-        abort();
-    }
-
-    // We don't need the temporary file anymore.
-    remove(testfile);
-
-    // Copy the crash directory.
-    memcpy(::gCrashDir, crashdir, len);
 }
 
 #endif

--- a/source/engine/common/i_crash_win32.cpp
+++ b/source/engine/common/i_crash_win32.cpp
@@ -30,7 +30,6 @@
 
 #if defined _WIN32 && defined _MSC_VER && !defined _DEBUG
 
-#define CRASH_DIR_LEN 1024
 #include "win32inc.h"
 #include <DbgHelp.h>
 #include <new.h>
@@ -38,16 +37,12 @@
 
 #include <exception>
 
+#include "cmdlib.h"
 #include "i_crash.h"
 #include "i_system.h"
 #include "m_fileio.h"
+#include "physfs.h"
 #include "mud_includes.h"
-
-
-/**
- * @brief An array containing the directory where crashes are written to.
- */
-static TCHAR gCrashDir[CRASH_DIR_LEN];
 
 // Fucntion pointer for MiniDumpWriteDump.
 typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
@@ -59,7 +54,7 @@ typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFi
 void writeMinidump(EXCEPTION_POINTERS *exceptionPtrs)
 {
     // Grab the debugging library.
-    HMODULE dbghelp = LoadLibrary("dbghelp.dll");
+    HMODULE dbghelp = LoadLibrary(L"dbghelp.dll");
     if (dbghelp == NULL)
     {
         // We can't load the debugging library - oh well.
@@ -77,10 +72,12 @@ void writeMinidump(EXCEPTION_POINTERS *exceptionPtrs)
     // Open a file to write our dump into.
     SYSTEMTIME dt;
     GetSystemTime(&dt);
-    char filename[CRASH_DIR_LEN];
-    sprintf_s(filename, sizeof(filename), "%s\\%s_g%s_%u_%4d%02d%02dT%02d%02d%02d.dmp", ::gCrashDir, GAMEEXE,
+    std::string filename = StrFormat("%s\\%s_g%s_%lu_%4d%02d%02dT%02d%02d%02d.dmp", M_GetWriteDir().c_str(), GAMEEXE,
               GitShortHash(), GetCurrentProcessId(), dt.wYear, dt.wMonth, dt.wDay, dt.wHour, dt.wMinute, dt.wSecond);
-    HANDLE hFile = CreateFile(filename, GENERIC_WRITE, FILE_SHARE_READ, 0, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, 0);
+    std::wstring wide_filename;
+    wide_filename.resize(filename.size() * 2);
+    PHYSFS_utf8ToUtf16(filename.data(), (PHYSFS_uint16 *)wide_filename.data(), wide_filename.size());
+    HANDLE hFile = CreateFileW(wide_filename.c_str(), GENERIC_WRITE, FILE_SHARE_READ, 0, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, 0);
     if (hFile == INVALID_HANDLE_VALUE)
     {
         // We couldn't create a dump file - oh well.
@@ -181,7 +178,7 @@ void I_SetCrashCallbacks()
     SetUnhandledExceptionFilter(sehCallback);
 
     // Intercept calls to std::terminate().
-    set_terminate(terminateCallback);
+    std::set_terminate(terminateCallback);
 
     // Pure virtual function calls.
     _set_purecall_handler(purecallCallback);
@@ -197,36 +194,6 @@ void I_SetCrashCallbacks()
     signal(SIGABRT, signalCallback);
     signal(SIGFPE, signalCallback);
     signal(SIGSEGV, signalCallback);
-}
-
-void I_SetCrashDir(const char *crashdir)
-{
-    std::string homedir;
-    TCHAR       testfile[MAX_PATH];
-
-    // Check to see if our crash dir is too big.
-    size_t len = strlen(crashdir);
-    if (len > CRASH_DIR_LEN)
-    {
-        I_FatalError("Crash directory \"%s\" is too long.  Please pass a correct -crashout param.", crashdir);
-        abort();
-    }
-
-    // Check to see if we can write to our crash directory.
-    UINT res = GetTempFileName(crashdir, "crash", 0, testfile);
-    if (res == 0 || res == ERROR_BUFFER_OVERFLOW)
-    {
-        I_FatalError("Crash directory \"%s\" is not writable.  Please point -crashout to "
-                     "a directory with write permissions.",
-                     crashdir);
-        abort();
-    }
-
-    // We don't need the temporary file anymore.
-    DeleteFile(testfile);
-
-    // Copy the crash directory.
-    memcpy(::gCrashDir, crashdir, len);
 }
 
 #endif

--- a/source/engine/common/win32inc.h
+++ b/source/engine/common/win32inc.h
@@ -35,7 +35,6 @@
 #endif // NOMINMAX;
 
 #define WIN32_LEAN_AND_MEAN
-#define UNICODE
 
 #include <windows.h>
 

--- a/source/engine/common/win32inc.h
+++ b/source/engine/common/win32inc.h
@@ -35,6 +35,7 @@
 #endif // NOMINMAX;
 
 #define WIN32_LEAN_AND_MEAN
+#define UNICODE
 
 #include <windows.h>
 

--- a/source/engine/server/i_main.cpp
+++ b/source/engine/server/i_main.cpp
@@ -165,17 +165,6 @@ int32_t __cdecl main(int32_t argc, char *argv[])
             exit(EXIT_SUCCESS);
         }
 
-        const char *crashdir = ::Args.CheckValue("-crashdir");
-        if (crashdir)
-        {
-            I_SetCrashDir(crashdir);
-        }
-        else
-        {
-            std::string writedir = M_GetWriteDir();
-            I_SetCrashDir(writedir.c_str());
-        }
-
         const char *CON_FILE = Args.CheckValue("-confile");
         if (CON_FILE)
             CON.open(CON_FILE, std::ios::in);
@@ -298,17 +287,6 @@ int32_t main(int32_t argc, char **argv)
             printf("MUD Server %s\n", NiceVersion());
             PHYSFS_deinit();
             exit(EXIT_SUCCESS);
-        }
-
-        const char *crashdir = ::Args.CheckValue("-crashdir");
-        if (crashdir)
-        {
-            I_SetCrashDir(crashdir);
-        }
-        else
-        {
-            std::string writedir = M_GetWriteDir();
-            I_SetCrashDir(writedir.c_str());
         }
 
         const char *CON_FILE = Args.CheckValue("-confile");

--- a/source/engine/server/i_system.cpp
+++ b/source/engine/server/i_system.cpp
@@ -270,30 +270,6 @@ void I_WaitVBL(int32_t count)
     I_Sleep(1000000LL * 1000LL * count / 70);
 }
 
-//
-// SubsetLanguageIDs
-//
-#ifdef _WIN32
-static void SubsetLanguageIDs(LCID id, LCTYPE type, int32_t idx)
-{
-    char  buf[8];
-    LCID  langid;
-    char *idp;
-
-    if (!GetLocaleInfo(id, type, buf, 8))
-        return;
-    langid = MAKELCID(strtoul(buf, NULL, 16), SORT_DEFAULT);
-    if (!GetLocaleInfo(langid, LOCALE_SABBREVLANGNAME, buf, 8))
-        return;
-    idp = (char *)(&LanguageIDs[idx]);
-    memset(idp, 0, 4);
-    idp[0] = tolower(buf[0]);
-    idp[1] = tolower(buf[1]);
-    idp[2] = tolower(buf[2]);
-    idp[3] = 0;
-}
-#endif
-
 EXTERN_CVAR(language)
 
 // Force the language to English (default)


### PR DESCRIPTION
This allows us to:
- Support detection of locales other than English for non-Windows systems
- Use the UNICODE Windows include without a compile error looking for the wide version of GetLocaleInfo
- Default to the users's PHYSFS write directory instead of optionally checking and testing the "crashdir" param

Incidentally I added local CMake kit files to the .gitignore list