### PR TITLE
Limit WAD usage and lump lookups to maps only

### DIFF
--- a/source_files/ddf/ddf_anim.h
+++ b/source_files/ddf/ddf_anim.h
@@ -44,10 +44,6 @@ class AnimationDefinition
     // -AJA- 2004/10/27: new SEQUENCE command for anims
     std::vector<std::string> pics_;
 
-    // first and last names in TEXTURE1/2 lump
-    std::string start_name_;
-    std::string end_name_;
-
     // how many 1/35s ticks each frame lasts
     int speed_;
 
@@ -87,9 +83,6 @@ class AnimationDefinitionContainer : public std::vector<AnimationDefinition *>
 extern AnimationDefinitionContainer animdefs; // -ACB- 2004/06/03 Implemented
 
 void DDFReadAnims(const std::string &data);
-
-// handle the BOOM lump
-void DDFConvertAnimatedLump(const uint8_t *data, int size);
 
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/ddf/ddf_attack.cc
+++ b/source_files/ddf/ddf_attack.cc
@@ -330,7 +330,7 @@ void DDFReadAtks(const std::string &data)
     DDFReadInfo attacks;
 
     attacks.tag      = "ATTACKS";
-    attacks.lumpname = "DDFATK";
+    attacks.short_name = "DDFATK";
 
     attacks.start_entry  = AttackStartEntry;
     attacks.parse_field  = AttackParseField;

--- a/source_files/ddf/ddf_boom.cc
+++ b/source_files/ddf/ddf_boom.cc
@@ -323,12 +323,12 @@ static void MakeBoomFloor(LineType *line, int number)
     {
     case 0: // Down
         line->f_.speed_down_ = 1 << speed;
-        line->f_.sfxdown_    = sfxdefs.GetEffect("STNMOV");
+        line->f_.sfxdown_    = sfxdefs.GetEffect("CRUSHER_MOVE");
         break;
 
     case 1: // Up;
         line->f_.speed_up_ = 1 << speed;
-        line->f_.sfxup_    = sfxdefs.GetEffect("STNMOV");
+        line->f_.sfxup_    = sfxdefs.GetEffect("CRUSHER_MOVE");
         break;
     }
 
@@ -415,12 +415,12 @@ static void MakeBoomCeiling(LineType *line, int number)
     {
     case 0: // Down
         line->c_.speed_down_ = 1 << speed;
-        line->c_.sfxdown_    = sfxdefs.GetEffect("STNMOV");
+        line->c_.sfxdown_    = sfxdefs.GetEffect("CRUSHER_MOVE");
         break;
 
     case 1: // Up;
         line->c_.speed_up_ = 1 << speed;
-        line->c_.sfxup_    = sfxdefs.GetEffect("STNMOV");
+        line->c_.sfxup_    = sfxdefs.GetEffect("CRUSHER_MOVE");
         break;
     }
 
@@ -456,13 +456,13 @@ static void MakeBoomDoor(LineType *line, int number)
 
     if (line->c_.speed_up_ > 7)
     {
-        line->c_.sfxup_   = sfxdefs.GetEffect("BDOPN");
-        line->c_.sfxdown_ = sfxdefs.GetEffect("BDCLS");
+        line->c_.sfxup_   = sfxdefs.GetEffect("FAST_DOOR_OPEN");
+        line->c_.sfxdown_ = sfxdefs.GetEffect("FAST_DOOR_CLOSE");
     }
     else
     {
-        line->c_.sfxup_   = sfxdefs.GetEffect("DOROPN");
-        line->c_.sfxdown_ = sfxdefs.GetEffect("DORCLS");
+        line->c_.sfxup_   = sfxdefs.GetEffect("DOOR_OPEN");
+        line->c_.sfxdown_ = sfxdefs.GetEffect("DOOR_CLOSE");
     }
 
     switch (kind & 2)
@@ -515,13 +515,13 @@ static void MakeBoomLockedDoor(LineType *line, int number)
 
     if (line->c_.speed_up_ > 7)
     {
-        line->c_.sfxup_   = sfxdefs.GetEffect("BDOPN");
-        line->c_.sfxdown_ = sfxdefs.GetEffect("BDCLS");
+        line->c_.sfxup_   = sfxdefs.GetEffect("FAST_DOOR_OPEN");
+        line->c_.sfxdown_ = sfxdefs.GetEffect("FAST_DOOR_CLOSE");
     }
     else
     {
-        line->c_.sfxup_   = sfxdefs.GetEffect("DOROPN");
-        line->c_.sfxdown_ = sfxdefs.GetEffect("DORCLS");
+        line->c_.sfxup_   = sfxdefs.GetEffect("DOOR_OPEN");
+        line->c_.sfxdown_ = sfxdefs.GetEffect("DOOR_CLOSE");
     }
 
     line->c_.wait_ = 150;
@@ -591,8 +591,8 @@ static void MakeBoomLift(LineType *line, int number)
 
     line->f_.speed_up_   = 2 << speed;
     line->f_.speed_down_ = line->f_.speed_up_;
-    line->f_.sfxstart_   = sfxdefs.GetEffect("PSTART");
-    line->f_.sfxstop_    = sfxdefs.GetEffect("PSTOP");
+    line->f_.sfxstart_   = sfxdefs.GetEffect("PLATFORM_START");
+    line->f_.sfxstop_    = sfxdefs.GetEffect("PLATFORM_STOP");
 
     switch (target)
     {
@@ -665,7 +665,7 @@ static void MakeBoomStair(LineType *line, int number)
     line->f_.speed_down_ = (1 << speed) / 4.0f;
     line->f_.speed_up_   = line->f_.speed_down_;
 
-    line->f_.sfxdown_ = sfxdefs.GetEffect("STNMOV");
+    line->f_.sfxdown_ = sfxdefs.GetEffect("STAIR_MOVE");
     line->f_.sfxup_   = line->f_.sfxdown_;
 
     if (igntxt)
@@ -690,7 +690,7 @@ static void MakeBoomCrusher(LineType *line, int number)
 
     if (!silent)
     {
-        line->c_.sfxup_   = sfxdefs.GetEffect("STNMOV");
+        line->c_.sfxup_   = sfxdefs.GetEffect("CRUSHER_MOVE");
         line->c_.sfxdown_ = line->c_.sfxup_;
     }
 }

--- a/source_files/ddf/ddf_colormap.h
+++ b/source_files/ddf/ddf_colormap.h
@@ -30,12 +30,6 @@ enum ColorSpecial
     kColorSpecialWhiten = 0x0002
 };
 
-struct ColormapCache
-{
-    uint8_t *data;
-    int      size;
-};
-
 class Colormap
 {
   public:
@@ -49,21 +43,12 @@ class Colormap
     // Member vars...
     std::string name_;
 
-    std::string lump_name_;
-    int lump_index_; // for raw BOOM colourmaps
-    std::string pack_name_;
-
-    int start_;
-    int length_;
-
     ColorSpecial special_;
 
     // colours for GL renderer
     RGBAColor gl_color_;
 
     RGBAColor font_colour_; // (computed only, not in DDF)
-
-    ColormapCache cache_;
 
     void *analysis_;
 

--- a/source_files/ddf/ddf_flat.cc
+++ b/source_files/ddf/ddf_flat.cc
@@ -106,7 +106,7 @@ void DDFReadFlat(const std::string &data)
     DDFReadInfo flats;
 
     flats.tag      = "FLATS";
-    flats.lumpname = "DDFFLAT";
+    flats.short_name = "DDFFLAT";
 
     flats.start_entry  = FlatStartEntry;
     flats.parse_field  = FlatParseField;

--- a/source_files/ddf/ddf_font.cc
+++ b/source_files/ddf/ddf_font.cc
@@ -108,7 +108,7 @@ static void FontFinishEntry(void)
         DDFError("Missing font image name.\n");
 
     if (dynamic_font->type_ == kFontTypeTrueType && dynamic_font->truetype_name_.empty())
-        DDFError("Missing font TTF/OTF lump/file name.\n");
+        DDFError("Missing font TTF/OTF file name.\n");
 
     if (dynamic_font->type_ == kFontTypeTrueType && !dynamic_font->truetype_smoothing_string_.empty())
     {
@@ -131,7 +131,7 @@ void DDFReadFonts(const std::string &data)
     DDFReadInfo fonts;
 
     fonts.tag      = "FONTS";
-    fonts.lumpname = "DDFFONT";
+    fonts.short_name = "DDFFONT";
 
     fonts.start_entry  = FontStartEntry;
     fonts.parse_field  = FontParseField;

--- a/source_files/ddf/ddf_game.cc
+++ b/source_files/ddf/ddf_game.cc
@@ -169,7 +169,7 @@ void DDFReadGames(const std::string &data)
     DDFReadInfo games;
 
     games.tag      = "GAMES";
-    games.lumpname = "DDFGAME";
+    games.short_name = "DDFGAME";
 
     games.start_entry  = GameStartEntry;
     games.parse_field  = GameParseField;

--- a/source_files/ddf/ddf_image.cc
+++ b/source_files/ddf/ddf_image.cc
@@ -167,7 +167,7 @@ void DDFReadImages(const std::string &data)
     DDFReadInfo images;
 
     images.tag      = "IMAGES";
-    images.lumpname = "DDFIMAGE";
+    images.short_name = "DDFIMAGE";
 
     images.start_entry  = ImageStartEntry;
     images.parse_field  = ImageParseField;

--- a/source_files/ddf/ddf_language.cc
+++ b/source_files/ddf/ddf_language.cc
@@ -140,7 +140,7 @@ void DDFReadLangs(const std::string &data)
     DDFReadInfo languages;
 
     languages.tag      = "LANGUAGES";
-    languages.lumpname = "DDFLANG";
+    languages.short_name = "DDFLANG";
 
     languages.start_entry  = LanguageStartEntry;
     languages.parse_field  = LanguageParseField;

--- a/source_files/ddf/ddf_level.cc
+++ b/source_files/ddf/ddf_level.cc
@@ -206,7 +206,7 @@ void DDFReadLevels(const std::string &data)
     DDFReadInfo levels;
 
     levels.tag      = "LEVELS";
-    levels.lumpname = "DDFLEVL";
+    levels.short_name = "DDFLEVL";
 
     levels.start_entry  = LevelStartEntry;
     levels.parse_field  = LevelParseField;

--- a/source_files/ddf/ddf_line.cc
+++ b/source_files/ddf/ddf_line.cc
@@ -418,7 +418,7 @@ void DDFReadLines(const std::string &data)
     DDFReadInfo lines;
 
     lines.tag      = "LINES";
-    lines.lumpname = "DDFLINE";
+    lines.short_name = "DDFLINE";
 
     lines.start_entry  = LinedefStartEntry;
     lines.parse_field  = LinedefParseField;

--- a/source_files/ddf/ddf_local.h
+++ b/source_files/ddf/ddf_local.h
@@ -65,8 +65,8 @@ struct DDFCommandList
 //
 struct DDFReadInfo
 {
-    // name of the lump, for error messages
-    const char *lumpname;
+    // acronym for error messages
+    const char *short_name;
 
     // the file has to start with <tag>
     const char *tag;

--- a/source_files/ddf/ddf_main.cc
+++ b/source_files/ddf/ddf_main.cc
@@ -718,7 +718,7 @@ void DDFMainReadFile(DDFReadInfo *readinfo, const std::string &data)
     bool firstgo       = true;
 
     cur_ddf_line_num = 1;
-    cur_ddf_filename = std::string(readinfo->lumpname);
+    cur_ddf_filename = readinfo->short_name;
     cur_ddf_entryname.clear();
 
     // WISH: don't make this copy, parse directly from the string
@@ -832,7 +832,7 @@ void DDFMainReadFile(DDFReadInfo *readinfo, const std::string &data)
 
             if (epi::StringPrefixCaseCompareASCII(std::string_view(memfileptr, 13), "#NOPATCHMENUS") == 0)
             {
-                if (epi::StringCaseCompareASCII(readinfo->lumpname, "DDFSTYLE") == 0)
+                if (epi::StringCaseCompareASCII(readinfo->short_name, "DDFSTYLE") == 0)
                 {
                     styledefs.patch_menus_allowed_ = false;
                 }

--- a/source_files/ddf/ddf_movie.cc
+++ b/source_files/ddf/ddf_movie.cc
@@ -89,7 +89,7 @@ static void MovieParseField(const char *field, const char *contents, int index, 
 static void MovieFinishEntry(void)
 {
     if (dynamic_movie->type_ == kMovieDataNone)
-        DDFError("No lump or packfile defined for %s!\n", dynamic_movie->name_.c_str());
+        DDFError("No packfile defined for %s!\n", dynamic_movie->name_.c_str());
 }
 
 static void MovieClearAll(void)
@@ -102,7 +102,7 @@ void DDFReadMovies(const std::string &data)
     DDFReadInfo movies;
 
     movies.tag      = "MOVIES";
-    movies.lumpname = "DDFMOVIE";
+    movies.short_name = "DDFMOVIE";
 
     movies.start_entry  = MovieStartEntry;
     movies.parse_field  = MovieParseField;
@@ -144,12 +144,7 @@ static void DDFMovieGetType(const char *info, void *storage)
     strncpy(keyword, info, colon - info);
     keyword[colon - info] = 0;
 
-    if (DDFCompareName(keyword, "LUMP") == 0)
-    {
-        dynamic_movie->type_ = kMovieDataLump;
-        MovieParseInfo(colon + 1);
-    }
-    else if (DDFCompareName(keyword, "PACK") == 0)
+    if (DDFCompareName(keyword, "PACK") == 0)
     {
         dynamic_movie->type_ = kMovieDataPackage;
         MovieParseInfo(colon + 1);

--- a/source_files/ddf/ddf_movie.h
+++ b/source_files/ddf/ddf_movie.h
@@ -23,8 +23,8 @@
 enum MovieDataType
 {
     kMovieDataNone,    // Default/dummy value
-    kMovieDataLump,    // load from lump in a WAD
     kMovieDataPackage, // load from an EPK
+    //kMovieDataFile // Do we need loose files? - Dasho
 };
 
 enum MovieScaling

--- a/source_files/ddf/ddf_playlist.cc
+++ b/source_files/ddf/ddf_playlist.cc
@@ -32,7 +32,7 @@ PlaylistEntryContainer playlist;
 static void DDFMusicParseInfo(const char *info)
 {
     static const char *const musstrtype[] = {"UNKNOWN", "MIDI", "OGG", nullptr};
-    static const char *const musinftype[] = {"UNKNOWN", "LUMP", "FILE", "PACK", nullptr};
+    static const char *const musinftype[] = {"UNKNOWN", "FILE", "PACK", nullptr};
 
     char charbuff[256];
     int  pos, i;
@@ -72,7 +72,7 @@ static void DDFMusicParseInfo(const char *info)
         else
         {
             dynamic_plentry->infotype_ = (DDFMusicDataType)i;
-            // Remained is the string reference: filename/lumpname
+            // Remained is the string reference: filename
             pos++;
             dynamic_plentry->info_ = &info[pos];
             return;
@@ -188,7 +188,7 @@ void DDFReadMusicPlaylist(const std::string &data)
     DDFReadInfo playlistinfo;
 
     playlistinfo.tag      = "PLAYLISTS";
-    playlistinfo.lumpname = "DDFPLAY";
+    playlistinfo.short_name = "DDFPLAY";
 
     playlistinfo.start_entry  = PlaylistStartEntry;
     playlistinfo.parse_field  = PlaylistParseField;

--- a/source_files/ddf/ddf_playlist.h
+++ b/source_files/ddf/ddf_playlist.h
@@ -37,10 +37,9 @@ enum DDFMusicType
 enum DDFMusicDataType
 {
     kDDFMusicDataUnknown    = 0,
-    kDDFMusicDataLump       = 1,
-    kDDFMusicDataFile       = 2,
-    kDDFMusicDataPackage    = 3,
-    kTotalDDFMusicDataTypes = 4
+    kDDFMusicDataFile,
+    kDDFMusicDataPackage,
+    kTotalDDFMusicDataTypes
 };
 
 class PlaylistEntry

--- a/source_files/ddf/ddf_sector.cc
+++ b/source_files/ddf/ddf_sector.cc
@@ -181,7 +181,7 @@ void DDFReadSectors(const std::string &data)
     DDFReadInfo sects;
 
     sects.tag      = "SECTORS";
-    sects.lumpname = "DDFSECT";
+    sects.short_name = "DDFSECT";
 
     sects.start_entry  = SectorStartEntry;
     sects.parse_field  = SectorParseField;

--- a/source_files/ddf/ddf_sfx.cc
+++ b/source_files/ddf/ddf_sfx.cc
@@ -31,7 +31,6 @@ SoundEffectDefinitionContainer sfxdefs;
 static SoundEffectDefinition dummy_sfx;
 
 static const DDFCommandList sfx_commands[] = {
-    DDF_FIELD("LUMP_NAME", dummy_sfx, lump_name_, DDFMainGetLumpName),
     DDF_FIELD("PACK_NAME", dummy_sfx, pack_name_, DDFMainGetString),
     DDF_FIELD("FILE_NAME", dummy_sfx, file_name_, DDFMainGetString),
     DDF_FIELD("SINGULAR", dummy_sfx, singularity_, DDFMainGetNumeric),
@@ -107,9 +106,9 @@ static void SoundParseField(const char *field, const char *contents, int index, 
 
 static void SoundFinishEntry(void)
 {
-    if (dynamic_sfx->lump_name_.empty() && dynamic_sfx->file_name_.empty() && dynamic_sfx->pack_name_.empty())
+    if (dynamic_sfx->file_name_.empty() && dynamic_sfx->pack_name_.empty())
     {
-        DDFError("Missing LUMP_NAME or PACK_NAME for sound.\n");
+        DDFError("Missing FILE_NAME or PACK_NAME for sound.\n");
     }
 }
 
@@ -123,7 +122,7 @@ void DDFReadSFX(const std::string &data)
     DDFReadInfo sfx_r;
 
     sfx_r.tag      = "SOUNDS";
-    sfx_r.lumpname = "DDFSFX";
+    sfx_r.short_name = "DDFSFX";
 
     sfx_r.start_entry  = SoundStartEntry;
     sfx_r.parse_field  = SoundParseField;
@@ -189,7 +188,6 @@ SoundEffectDefinition::~SoundEffectDefinition()
 //
 void SoundEffectDefinition::CopyDetail(SoundEffectDefinition &src)
 {
-    lump_name_        = src.lump_name_;
     file_name_        = src.file_name_;
     pack_name_        = src.pack_name_;
 
@@ -210,7 +208,6 @@ void SoundEffectDefinition::CopyDetail(SoundEffectDefinition &src)
 //
 void SoundEffectDefinition::Default()
 {
-    lump_name_.clear();
     file_name_.clear();
     pack_name_.clear();
 

--- a/source_files/ddf/ddf_sfx.h
+++ b/source_files/ddf/ddf_sfx.h
@@ -47,7 +47,6 @@ class SoundEffectDefinition
     std::string name_;
 
     // full sound lump name (or file name)
-    std::string lump_name_;
     std::string file_name_;
     std::string pack_name_;
 

--- a/source_files/ddf/ddf_style.cc
+++ b/source_files/ddf/ddf_style.cc
@@ -190,7 +190,7 @@ void DDFReadStyles(const std::string &data)
     DDFReadInfo styles;
 
     styles.tag      = "STYLES";
-    styles.lumpname = "DDFSTYLE";
+    styles.short_name = "DDFSTYLE";
 
     styles.start_entry  = StyleStartEntry;
     styles.parse_field  = StyleParseField;

--- a/source_files/ddf/ddf_switch.cc
+++ b/source_files/ddf/ddf_switch.cc
@@ -119,7 +119,7 @@ void DDFReadSwitch(const std::string &data)
     DDFReadInfo switches;
 
     switches.tag      = "SWITCHES";
-    switches.lumpname = "DDFSWTH";
+    switches.short_name = "DDFSWTH";
 
     switches.start_entry  = SwitchStartEntry;
     switches.parse_field  = SwitchParseField;
@@ -214,65 +214,6 @@ SwitchDefinition *SwitchDefinitionContainer::Find(const char *name)
     }
 
     return nullptr;
-}
-
-//----------------------------------------------------------------------------
-
-void DDFConvertSwitchesLump(const uint8_t *data, int size)
-{
-    // handles the Boom SWITCHES lump (in a wad).
-
-    if (size < 20)
-        return;
-
-    std::string text = "<SWITCHES>\n\n";
-
-    for (; size >= 20; data += 20, size -= 20)
-    {
-        if (data[18] == 0) // end marker
-            break;
-
-        char off_name[9];
-        char on_name[9];
-
-        // clear to zeroes to prevent garbage being passed to DDF
-        memset(off_name, 0, 9);
-        memset(on_name, 0, 9);
-
-        // make sure names are NUL-terminated
-        memcpy(off_name, data + 0, 8);
-        off_name[8] = 0;
-        memcpy(on_name, data + 9, 8);
-        on_name[8] = 0;
-
-        LogDebug("- SWITCHES LUMP: off '%s' : on '%s'\n", off_name, on_name);
-
-        // ignore zero-length names
-        if (off_name[0] == 0 || on_name[0] == 0)
-            continue;
-
-        // create the DDF equivalent...
-        text += "[";
-        text += on_name;
-        text += "]\n";
-
-        text += "on_texture  = \"";
-        text += on_name;
-        text += "\";\n";
-
-        text += "off_texture = \"";
-        text += off_name;
-        text += "\";\n";
-
-        text += "on_sound  = \"SWTCHN\";\n";
-        text += "off_sound = \"SWTCHN\";\n";
-        text += "\n";
-    }
-
-    // DEBUG:
-    // DDFDumpFile(text);
-
-    DDFAddFile(kDDFTypeSwitch, text, "Boom SWITCHES lump");
 }
 
 //--- editor settings ---

--- a/source_files/ddf/ddf_switch.h
+++ b/source_files/ddf/ddf_switch.h
@@ -86,8 +86,5 @@ extern SwitchDefinitionContainer switchdefs; // -ACB- 2004/06/04 Implemented
 
 void DDFReadSwitch(const std::string &data);
 
-// handle the BOOM lump
-void DDFConvertSwitchesLump(const uint8_t *data, int size);
-
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -795,7 +795,7 @@ void DDFReadThings(const std::string &data)
     DDFReadInfo things;
 
     things.tag      = "THINGS";
-    things.lumpname = "DDFTHING";
+    things.short_name = "DDFTHING";
 
     things.start_entry  = ThingStartEntry;
     things.parse_field  = ThingParseField;

--- a/source_files/ddf/ddf_weapon.cc
+++ b/source_files/ddf/ddf_weapon.cc
@@ -572,7 +572,7 @@ void DDFReadWeapons(const std::string &data)
     DDFReadInfo weapons;
 
     weapons.tag      = "WEAPONS";
-    weapons.lumpname = "DDFWEAP";
+    weapons.short_name = "DDFWEAP";
 
     weapons.start_entry  = WeaponStartEntry;
     weapons.parse_field  = WeaponParseField;

--- a/source_files/edge/con_main.cc
+++ b/source_files/edge/con_main.cc
@@ -142,7 +142,7 @@ int ConsoleCommandReadme(char **argv, int argc)
     epi::File *readme_file = nullptr;
 
     // Check well known readme filenames
-    for (auto name : readme_names)
+    for (const std::string &name : readme_names)
     {
         readme_file = OpenFileFromPack(name);
         if (readme_file)
@@ -161,30 +161,6 @@ int ConsoleCommandReadme(char **argv, int argc)
             if (readme_file)
                 break;
         }
-    }
-
-    // Check for WADINFO or README lumps
-    if (!readme_file)
-    {
-        if (IsLumpInAnyWad("WADINFO"))
-            readme_file = LoadLumpAsFile("WADINFO");
-        else if (IsLumpInAnyWad("README"))
-            readme_file = LoadLumpAsFile("README");
-    }
-
-    // Check for an EDGEGAME lump or file and print (if it has text; these
-    // aren't required to)
-    if (!readme_file)
-    {
-        // Datafile at index 1 should always be either the IWAD or standalone
-        // EPK
-        if (data_files[1]->wad_)
-        {
-            if (IsLumpInAnyWad("EDGEGAME"))
-                readme_file = LoadLumpAsFile("EDGEGAME");
-        }
-        else
-            readme_file = OpenFileFromPack("EDGEGAME.txt");
     }
 
     if (!readme_file)

--- a/source_files/edge/f_interm.cc
+++ b/source_files/edge/f_interm.cc
@@ -411,7 +411,7 @@ static void DrawLevelFinished(void)
     // If we have a custom mapname graphic e.g.CWILVxx then use that
     if (level_names[0])
     {
-        if (IsLumpInPwad(level_names[0]->name_.c_str()))
+        if (IsFileInAddon(level_names[0]->name_.c_str()))
         {
             w1 = level_names[0]->ScaledWidthActual();
             h1 = level_names[0]->ScaledHeightActual();
@@ -486,7 +486,7 @@ static void DrawLevelFinished(void)
 
     HUDSetAlignment(0, -1); // center it
     // If we have a custom Finished graphic e.g.WIF then use that
-    if (IsLumpInPwad(finished->name_.c_str()))
+    if (IsFileInAddon(finished->name_.c_str()))
     {
         w1 = finished->ScaledWidthActual();
         h1 = finished->ScaledHeightActual();
@@ -575,7 +575,7 @@ static void DrawEnteringLevel(void)
     HUDSetAlignment(0, -1); // center it
 
     // If we have a custom Entering graphic e.g.WIENTER then use that
-    if (IsLumpInPwad(entering->name_.c_str()))
+    if (IsFileInAddon(entering->name_.c_str()))
     {
         w1 = entering->ScaledWidthActual();
         h1 = entering->ScaledHeightActual();
@@ -612,7 +612,7 @@ static void DrawEnteringLevel(void)
     // If we have a custom mapname graphic e.g.CWILVxx then use that
     if (level_names[1])
     {
-        if (IsLumpInPwad(level_names[1]->name_.c_str()))
+        if (IsFileInAddon(level_names[1]->name_.c_str()))
         {
             w1 = level_names[1]->ScaledWidthActual();
             h1 = level_names[1]->ScaledHeightActual();
@@ -766,7 +766,7 @@ static float TimeWidth(int t, bool drawText = false)
         if (t > 3599)
         {
             // "sucks"
-            if ((sucks) && (IsLumpInPwad(sucks->name_.c_str())))
+            if ((sucks) && (IsFileInAddon(sucks->name_.c_str())))
                 return sucks->ScaledWidthActual();
             else
                 return single_player_intermission_style->fonts_[StyleDefinition::kTextSectionAlternate]->StringWidth(
@@ -845,7 +845,7 @@ static void DrawTime(float x, float y, int t, bool drawText = false)
         if (t > 3599)
         {
             // "sucks"
-            if ((sucks) && (IsLumpInPwad(sucks->name_.c_str())))
+            if ((sucks) && (IsFileInAddon(sucks->name_.c_str())))
                 HUDDrawImage(x, y, sucks);
             else
                 HUDWriteText(single_player_intermission_style, StyleDefinition::kTextSectionTitle, x, y, "Sucks");
@@ -1560,7 +1560,7 @@ static void DrawSinglePlayerStats(void)
     bool drawTextBased = true;
     if (kills != nullptr)
     {
-        if (IsLumpInPwad(kills->name_.c_str()))
+        if (IsFileInAddon(kills->name_.c_str()))
             drawTextBased = false;
         else
             drawTextBased = true;
@@ -1606,7 +1606,7 @@ static void DrawSinglePlayerStats(void)
         s = s + "%";
     }
 
-    if ((items) && (IsLumpInPwad(items->name_.c_str())))
+    if ((items) && (IsFileInAddon(items->name_.c_str())))
     {
         HUDDrawImage(kSinglePlayerStateStatsX, kSinglePlayerStateStatsY + lh, items);
         if (!s.empty())
@@ -1633,7 +1633,7 @@ static void DrawSinglePlayerStats(void)
         s = s + "%";
     }
 
-    if ((single_player_secret) && (IsLumpInPwad(single_player_secret->name_.c_str())))
+    if ((single_player_secret) && (IsFileInAddon(single_player_secret->name_.c_str())))
     {
         HUDDrawImage(kSinglePlayerStateStatsX, kSinglePlayerStateStatsY + 2 * lh, single_player_secret);
         if (!s.empty())
@@ -1652,7 +1652,7 @@ static void DrawSinglePlayerStats(void)
                 kSinglePlayerStateStatsY + 2 * lh, s.c_str());
     }
 
-    if ((time_image) && (IsLumpInPwad(time_image->name_.c_str())))
+    if ((time_image) && (IsFileInAddon(time_image->name_.c_str())))
     {
         HUDDrawImage(kSinglePlayerStateTimeX, kSinglePlayerStateTimeY, time_image);
         DrawTime(160 - kSinglePlayerStateTimeX - TimeWidth(count_time), kSinglePlayerStateTimeY, count_time);
@@ -1668,7 +1668,7 @@ static void DrawSinglePlayerStats(void)
     // -KM- 1998/11/25 Removed episode check. Replaced with partime check
     if (intermission_stats.par_time)
     {
-        if ((par) && (IsLumpInPwad(par->name_.c_str())))
+        if ((par) && (IsFileInAddon(par->name_.c_str())))
         {
             HUDDrawImage(170, kSinglePlayerStateTimeY, par);
             DrawTime(320 - kSinglePlayerStateTimeX - TimeWidth(count_par), kSinglePlayerStateTimeY, count_par);

--- a/source_files/edge/hu_font.cc
+++ b/source_files/edge/hu_font.cc
@@ -325,20 +325,11 @@ void Font::LoadFontTTF()
 
         if (!truetype_buffer_)
         {
-            epi::File *F;
+            truetype_buffer_ = OpenMatchingPackFileInMemory(epi::GetStem(definition_->truetype_name_), {".ttf", ".otf"}, nullptr);
 
-            if (!epi::GetExtension(definition_->truetype_name_).empty()) // check for pack file
-                F = OpenFileFromPack(definition_->truetype_name_);
-            else
-                F = LoadLumpAsFile(CheckLumpNumberForName(definition_->truetype_name_.c_str()));
-
-            if (!F)
+            if (!truetype_buffer_)
                 FatalError("LoadFontTTF: '%s' not found for font %s.\n", definition_->truetype_name_.c_str(),
                            definition_->name_.c_str());
-
-            truetype_buffer_ = F->LoadIntoMemory();
-
-            delete F;
         }
 
         if (!truetype_info_)

--- a/source_files/edge/i_movie.cc
+++ b/source_files/edge/i_movie.cc
@@ -120,18 +120,13 @@ void PlayMovie(const std::string &name)
 
     int      length = 0;
 
-    if (movie->type_ == kMovieDataLump)
-        movie_bytes = LoadLumpIntoMemory(movie->info_.c_str(), &length);
-    else
+    epi::File *mf = OpenFileFromPack(movie->info_.c_str());
+    if (mf)
     {
-        epi::File *mf = OpenFileFromPack(movie->info_.c_str());
-        if (mf)
-        {
-            movie_bytes  = mf->LoadIntoMemory();
-            length = mf->GetLength();
-        }
-        delete mf;
+        movie_bytes  = mf->LoadIntoMemory();
+        length = mf->GetLength();
     }
+    delete mf;
 
     if (!movie_bytes)
     {

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -117,8 +117,6 @@ static int chosen_episode;
 
 // SOUNDS
 SoundEffect *sound_effect_swtchn;
-SoundEffect *sound_effect_tink;
-SoundEffect *sound_effect_radio;
 SoundEffect *sound_effect_oof;
 SoundEffect *sound_effect_pstop;
 SoundEffect *sound_effect_stnmov;
@@ -3005,34 +3003,34 @@ void MenuInitialize(void)
         // Check for custom menu graphics in pwads:
         // If we have them then use them instead of our
         //  text-based ones.
-        if (IsLumpInPwad("M_NEWG"))
+        if (IsFileInAddon("M_NEWG"))
             custom_MenuMain = true;
 
-        if (IsLumpInPwad("M_LOADG"))
+        if (IsFileInAddon("M_LOADG"))
             custom_MenuMain = true;
 
-        if (IsLumpInPwad("M_SAVEG"))
+        if (IsFileInAddon("M_SAVEG"))
             custom_MenuMain = true;
 
-        if (IsLumpInPwad("M_EPISOD"))
+        if (IsFileInAddon("M_EPISOD"))
             custom_MenuEpisode = true;
 
-        if (IsLumpInPwad("M_EPI1"))
+        if (IsFileInAddon("M_EPI1"))
             custom_MenuEpisode = true;
 
-        if (IsLumpInPwad("M_EPI2"))
+        if (IsFileInAddon("M_EPI2"))
             custom_MenuEpisode = true;
 
-        if (IsLumpInPwad("M_EPI3"))
+        if (IsFileInAddon("M_EPI3"))
             custom_MenuEpisode = true;
 
-        if (IsLumpInPwad("M_EPI4"))
+        if (IsFileInAddon("M_EPI4"))
             custom_MenuEpisode = true;
 
-        if (IsLumpInPwad("M_JKILL"))
+        if (IsFileInAddon("M_JKILL"))
             custom_MenuDifficulty = true;
 
-        if (IsLumpInPwad("M_NMARE"))
+        if (IsFileInAddon("M_NMARE"))
             custom_MenuDifficulty = true;
     }
 
@@ -3042,15 +3040,15 @@ void MenuInitialize(void)
 
     menu_doom = ImageLookup("M_DOOM");
 
-    if (IsLumpInAnyWad("HELP1")) // doom or shareware doom
+    if (IsFileAnywhere("HELP1")) // doom or shareware doom
     {
         menu_read_this[0] = ImageLookup("HELP1");
-        if (IsLumpInAnyWad("HELP2"))
+        if (IsFileAnywhere("HELP2"))
             menu_read_this[1] = ImageLookup("HELP2");  // Shareware doom
         else
             menu_read_this[1] = ImageLookup("CREDIT"); // Full doom
     }
-    else if (IsLumpInAnyWad("HELP")) // doom 2
+    else if (IsFileAnywhere("HELP")) // doom 2
     {
         menu_read_this[0]           = ImageLookup("HELP");
         menu_read_this[1]           = ImageLookup("CREDIT"); // Unnecessary since we won't see it anyway...
@@ -3067,8 +3065,6 @@ void MenuInitialize(void)
     // Lobo 2022: Use new sfx definitions so we don't have to share names with
     // normal doom sfx.
     sound_effect_swtchn = sfxdefs.GetEffect("MENU_IN");  // Enter Menu
-    sound_effect_tink   = sfxdefs.GetEffect("TINK");     // unused
-    sound_effect_radio  = sfxdefs.GetEffect("RADIO");    // unused
     sound_effect_oof    = sfxdefs.GetEffect("MENU_INV"); // invalid choice
     sound_effect_pstop  = sfxdefs.GetEffect("MENU_MOV"); // moving cursor in a menu
     sound_effect_stnmov = sfxdefs.GetEffect("MENU_SLD"); // slider move

--- a/source_files/edge/m_menu.h
+++ b/source_files/edge/m_menu.h
@@ -45,8 +45,6 @@ extern int key_gamma_toggle;
 
 // the so-called "bastard sfx" used for the menus
 extern struct SoundEffect *sound_effect_swtchn;
-extern struct SoundEffect *sound_effect_tink;
-extern struct SoundEffect *sound_effect_radio;
 extern struct SoundEffect *sound_effect_oof;
 extern struct SoundEffect *sound_effect_pstop;
 extern struct SoundEffect *sound_effect_stnmov;

--- a/source_files/edge/p_enemy.cc
+++ b/source_files/edge/p_enemy.cc
@@ -662,11 +662,12 @@ void A_PlayerScream(MapObject *mo)
 
     sound = mo->info_->deathsound_;
 
-    if ((mo->health_ < -50) && (IsLumpInAnyWad("DSPDIEHI")))
+    if (mo->health_ < -50)
     {
         // if the player dies and unclipped health is < -50%...
-
-        sound = sfxdefs.GetEffect("PDIEHI");
+        SoundEffect *really_dead = sfxdefs.GetEffect("PLAYER_OVERKILL");
+        if (really_dead)
+            sound = really_dead;
     }
 
     StartSoundEffect(sound, GetSoundEffectCategory(mo), mo);

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -572,8 +572,7 @@ static void UpdatePowerups(Player *player)
     {
         float s = player->powers_[kPowerTypeInvulnerable];
 
-        // -ACB- FIXME!!! Catch lookup failure!
-        player->effect_colourmap_ = colormaps.Lookup("ALLWHITE");
+        player->effect_colourmap_ = colormaps.Lookup("INVULNERABILITY");
         player->effect_left_      = (s <= 0) ? 0 : HMM_MIN(int(s), kMaximumEffectTime);
     }
     else if (player->powers_[kPowerTypeInfrared] > 0)
@@ -586,8 +585,7 @@ static void UpdatePowerups(Player *player)
     {
         float s = player->powers_[kPowerTypeNightVision];
 
-        // -ACB- FIXME!!! Catch lookup failure!
-        player->effect_colourmap_ = colormaps.Lookup("ALLGREEN");
+        player->effect_colourmap_ = colormaps.Lookup("INFRAVISION");
         player->effect_left_      = (s <= 0) ? 0 : HMM_MIN(int(s), kMaximumEffectTime);
     }
     else if (player->powers_[kPowerTypeBerserk] > 0) // Lobo 2021: Un-Hardcode Berserk colour tint
@@ -874,11 +872,11 @@ void CreatePlayer(int pnum, bool is_bot)
 
     if (!sfx_jpidle)
     {
-        sfx_jpidle = sfxdefs.GetEffect("JPIDLE", false);
-        sfx_jpmove = sfxdefs.GetEffect("JPMOVE", false);
-        sfx_jprise = sfxdefs.GetEffect("JPRISE", false);
-        sfx_jpdown = sfxdefs.GetEffect("JPDOWN", false);
-        sfx_jpflow = sfxdefs.GetEffect("JPFLOW", false);
+        sfx_jpidle = sfxdefs.GetEffect("FLIGHT_IDLE", false);
+        sfx_jpmove = sfxdefs.GetEffect("FLIGHT_MOVE", false);
+        sfx_jprise = sfxdefs.GetEffect("FLIGHT_ASCEND", false);
+        sfx_jpdown = sfxdefs.GetEffect("FLIGHT_DESCEND", false);
+        sfx_jpflow = sfxdefs.GetEffect("FLIGHT_EXPIRING", false);
     }
 }
 

--- a/source_files/edge/s_cache.cc
+++ b/source_files/edge/s_cache.cc
@@ -105,24 +105,15 @@ static bool DoCacheLoad(SoundEffectDefinition *def, SoundData *buf)
         F              = epi::FileOpen(fn, epi::kFileAccessRead | epi::kFileAccessBinary);
         if (!F)
         {
-            DebugOrError("SFX Loader: Can't Find File '%s'\n", fn.c_str());
+            DebugOrError("SFX Loader: Can't Find file '%s'\n", fn.c_str());
             return false;
         }
         fmt = SoundFilenameToFormat(def->file_name_);
     }
     else
     {
-        int lump = -1;
-        lump     = CheckLumpNumberForName(def->lump_name_.c_str());
-        if (lump < 0)
-        {
-            // Just write a debug message for SFX lumps; this prevents spam
-            // amongst the various IWADs
-            DebugOrError("SFX Loader: Missing sound lump: %s\n", def->lump_name_.c_str());
-            return false;
-        }
-        F = LoadLumpAsFile(lump);
-        EPI_ASSERT(F);
+        DebugOrError("SFX Loader: No filename given for %s\n", def->name_.c_str());
+        return false;
     }
 
     // Load the data into the buffer

--- a/source_files/edge/s_music.cc
+++ b/source_files/edge/s_music.cc
@@ -88,7 +88,7 @@ void ChangeMusic(int entry_number, bool loop)
         F = epi::FileOpen(fn, epi::kFileAccessRead | epi::kFileAccessBinary);
         if (!F)
         {
-            LogWarning("ChangeMusic: Can't Find File '%s'\n", fn.c_str());
+            LogWarning("ChangeMusic: Can't find file '%s'\n", fn.c_str());
             return;
         }
         break;
@@ -98,26 +98,14 @@ void ChangeMusic(int entry_number, bool loop)
         F = OpenFileFromPack(play->info_);
         if (!F)
         {
-            LogWarning("ChangeMusic: PK3 entry '%s' not found.\n", play->info_.c_str());
+            LogWarning("ChangeMusic: pack entry '%s' not found.\n", play->info_.c_str());
             return;
         }
-        break;
-    }
-
-    case kDDFMusicDataLump: {
-        int lump = CheckLumpNumberForName(play->info_.c_str());
-        if (lump < 0)
-        {
-            LogWarning("ChangeMusic: LUMP '%s' not found.\n", play->info_.c_str());
-            return;
-        }
-
-        F = LoadLumpAsFile(lump);
         break;
     }
 
     default:
-        LogPrint("ChangeMusic: invalid method %d for MUS/MIDI\n", play->infotype_);
+        LogPrint("ChangeMusic: invalid type %d for music\n", play->infotype_);
         return;
     }
 
@@ -140,16 +128,8 @@ void ChangeMusic(int entry_number, bool loop)
 
     SoundFormat fmt = kSoundUnknown;
 
-    if (play->infotype_ == kDDFMusicDataLump)
-    {
-        // lumps must use auto-detection based on their contents
-        fmt = DetectSoundFormat(data, length);
-    }
-    else
-    {
-        // for FILE and PACK, use the file extension
-        fmt = SoundFilenameToFormat(play->info_);
-    }
+    // for FILE and PACK, use the file extension
+    fmt = SoundFilenameToFormat(play->info_);
 
     // NOTE: players are responsible for freeing 'data'
 

--- a/source_files/edge/script/compat/lua_compat.cc
+++ b/source_files/edge/script/compat/lua_compat.cc
@@ -44,7 +44,7 @@ void LuaLoadScripts()
         }
     }
 
-    if (IsLumpInPwad("STBAR"))
+    if (IsFileInAddon("STBAR"))
     {
         LuaSetBoolean(global_lua_state, "hud", "custom_stbar", true);
     }

--- a/source_files/edge/w_files.h
+++ b/source_files/edge/w_files.h
@@ -89,7 +89,7 @@ epi::File *OpenFileFromPack(const std::string &name);
 
 void DoPackSubstitutions(void);
 
-uint8_t *OpenPackOrLumpInMemory(const std::string &name, const std::vector<std::string> &extensions, int *length);
+uint8_t *OpenMatchingPackFileInMemory(const std::string &name, const std::vector<std::string> &extensions, int *length);
 
 int CheckPackFilesForName(const std::string &name);
 

--- a/source_files/edge/w_flat.cc
+++ b/source_files/edge/w_flat.cc
@@ -161,19 +161,6 @@ static void AddGraphicAnimation(AnimationDefinition *anim)
     delete[] users;
 }
 
-struct CompareFlatPredicate
-{
-    inline bool operator()(const int &A, const int &B) const
-    {
-        int cmp = strcmp(GetLumpNameFromIndex(A), GetLumpNameFromIndex(B));
-        if (cmp < 0)
-            return true;
-        if (cmp > 0)
-            return false;
-        return A < B;
-    }
-};
-
 //
 // InitializeAnimations
 //

--- a/source_files/edge/w_wad.h
+++ b/source_files/edge/w_wad.h
@@ -31,38 +31,20 @@
 #include "epi_file.h"
 
 int CheckLumpNumberForName(const char *name);
-// Like above, but returns the data file index instead of the sortedlump index
-int CheckDataFileIndexForName(const char *name);
 
 int CheckXGLLumpNumberForName(const char *name);
 int CheckMapLumpNumberForName(const char *name);
 
-// Unlike check, will FatalError if not present
-int GetLumpNumberForName(const char *name);
-
 int GetLumpLength(int lump);
 
 uint8_t *LoadLumpIntoMemory(int lump, int *length = nullptr);
-uint8_t *LoadLumpIntoMemory(const char *name, int *length = nullptr);
-
-std::string LoadLumpAsString(int lump);
-std::string LoadLumpAsString(const char *name);
 
 bool        IsLumpIndexValid(int lump);
 bool        VerifyLump(int lump, const char *name);
-const char *GetLumpNameFromIndex(int lump);
 
-epi::File *LoadLumpAsFile(int lump);
-epi::File *LoadLumpAsFile(const char *name);
+bool IsFileInAddon(const char *name);
 
-int               GetDataFileIndexForLump(int lump);
-
-bool IsLumpInPwad(const char *name);
-
-bool IsLumpInAnyWad(const char *name);
-
-// Returns game name if EDGEGAME lump found, otherwise empty string
-std::string CheckForEdgeGameLump(epi::File *file);
+bool IsFileAnywhere(const char *name);
 
 void BuildXGLNodes(void);
 


### PR DESCRIPTION
This limits the usage of WADs and lumps to maps only in anticipation of ditching support for the WAD format altogether.