### PR TITLE
Remove unwanted rendering features and miscellaneous Doom-isms

### DIFF
--- a/docs/specifications/UDMF EDGE-Classic Extensions.txt
+++ b/docs/specifications/UDMF EDGE-Classic Extensions.txt
@@ -129,6 +129,11 @@ Note: All <bool> fields default to false unless mentioned otherwise.
                                  // - EDGE-Classic additionally supports fogdensity values of 510-1020, which would be equivalent to the 50-100% SECTORS.DDF
                                  //   FOG_DENSITY scale, but map editors may clamp this value to 510. Switching editors, manually editing
                                  //   the map's TEXTMAP, or using a DDF sector fog special instead may be necessary in these cases.
+
+      liquidheight = <integer>;     // Height of liquid surface. Default = 0.
+      liquidtexture = <string>;     // Flat to use for liquid surface. No valid default.
+      liquidcolor = <integer>;      // Fog color for this sector, in 0xRRGGBB format. Default is X11's Steel Blue color (0x4682B4).
+      liquidlightlevel = <integer>; // Light level when view height is under the liquid surface. Default is 144. (darker than default sector light levels)
    }
 
    thing

--- a/source_files/ajbsp/bsp_level.cc
+++ b/source_files/ajbsp/bsp_level.cc
@@ -498,7 +498,7 @@ void ParseUDMF_Block(epi::Lexer &lex, int cur_type)
         line->self_referencing = (line->left && line->right && (line->left->sector == line->right->sector));
 
         if (line->self_referencing)
-            line->is_precious = true;
+            LogWarning("AJBSP: Map %s has self-referencing linedefs, which are not supported!\n", current_map_name.c_str());
     }
 }
 

--- a/source_files/ajbsp/bsp_local.h
+++ b/source_files/ajbsp/bsp_local.h
@@ -121,9 +121,6 @@ struct Linedef
     // line is marked two-sided
     bool two_sided;
 
-    // prefer not to split
-    bool is_precious;
-
     // zero length (line should be totally ignored)
     bool zero_length;
 

--- a/source_files/ajbsp/bsp_node.cc
+++ b/source_files/ajbsp/bsp_node.cc
@@ -366,12 +366,6 @@ bool EvalPartitionWorker(QuadTree *tree, Seg *part, double best_cost, EvalInfo *
         //       may fail to detect the sector being cut in half.  Thanks
         //       to Janis Legzdinsh for spotting this obscure bug.
 
-        if (fa <= kEpsilon || fb <= kEpsilon)
-        {
-            if (check->linedef_ != nullptr && check->linedef_->is_precious)
-                info->cost += 40.0 * split_cost * kPreciousCostMultiplier;
-        }
-
         /* check for right side */
         if (a > -kEpsilon && b > -kEpsilon)
         {
@@ -429,15 +423,7 @@ bool EvalPartitionWorker(QuadTree *tree, Seg *part, double best_cost, EvalInfo *
 
         info->splits++;
 
-        // If the linedef associated with this seg has a tag >= 900, treat
-        // it as precious; i.e. don't split it unless all other options
-        // are exhausted.  This is used to protect deep water and invisible
-        // lifts/stairs from being messed up accidentally by splits.
-
-        if (check->linedef_ && check->linedef_->is_precious)
-            info->cost += 100.0 * split_cost * kPreciousCostMultiplier;
-        else
-            info->cost += 100.0 * split_cost;
+        info->cost += 100.0 * split_cost;
 
         // -AJA- check if the split point is very close to one end, which
         //       is an undesirable situation (producing very short segs).
@@ -532,10 +518,6 @@ void EvaluateFastWorker(QuadTree *tree, Seg **best_H, Seg **best_V, int mid_x, i
     {
         /* ignore minisegs as partition candidates */
         if (part->linedef_ == nullptr)
-            continue;
-
-        /* ignore self-ref lines as partition candidates */
-        if (part->linedef_->is_precious)
             continue;
 
         if (AlmostEquals(part->pdy_, 0.0))

--- a/source_files/ddf/ddf_game.cc
+++ b/source_files/ddf/ddf_game.cc
@@ -287,10 +287,8 @@ static void DDFGameGetPic(const char *info, void *storage)
     dynamic_gamedef->titlepics_.push_back(info);
 }
 
-static DDFSpecialFlags lighting_names[] = {{"DOOM", kLightingModelDoom, 0},
-                                           {"DOOMISH", kLightingModelDoomish, 0},
+static DDFSpecialFlags lighting_names[] = {{"DOOMISH", kLightingModelDoomish, 0},
                                            {"FLAT", kLightingModelFlat, 0},
-                                           {"VERTEX", kLightingModelVertex, 0},
                                            {nullptr, 0, 0}};
 
 void DDFGameGetLighting(const char *info, void *storage)

--- a/source_files/ddf/ddf_game.h
+++ b/source_files/ddf/ddf_game.h
@@ -131,16 +131,10 @@ class IntermissionAnimationInfoContainer : public std::vector<IntermissionAnimat
 
 enum LightingModel
 {
-    // standard Doom shading
-    kLightingModelDoom = 0,
     // Doom shading without the brighter N/S, darker E/W walls
     kLightingModelDoomish = 1,
     // flat lighting (no shading at all)
     kLightingModelFlat = 2,
-    // vertex lighting
-    kLightingModelVertex = 3,
-    // Invalid (-ACB- 2003/10/06: MSVC wants the invalid value as part of the
-    // enum)
     kLightingModelInvalid = 999
 };
 

--- a/source_files/ddf/ddf_level.cc
+++ b/source_files/ddf/ddf_level.cc
@@ -29,7 +29,6 @@
 
 static void DDFLevelGetSpecials(const char *info);
 static void DDFLevelGetPic(const char *info, void *storage);
-static void DDFLevelGetSkyStretch(const char *info, void *storage);
 static void DDFLevelGetWistyle(const char *info, void *storage);
 
 MapDefinitionContainer mapdefs;
@@ -67,7 +66,6 @@ static const DDFCommandList level_commands[] = {
     DDF_FIELD("AUTHOR", dummy_level, author_, DDFMainGetString),
     DDF_FIELD("NAME_GRAPHIC", dummy_level, namegraphic_, DDFMainGetLumpName),
     DDF_FIELD("SKY_TEXTURE", dummy_level, sky_, DDFMainGetLumpName),
-    DDF_FIELD("SKY_STRETCH", dummy_level, forced_skystretch_, DDFLevelGetSkyStretch),
     DDF_FIELD("MUSIC_ENTRY", dummy_level, music_, DDFMainGetNumeric),
     DDF_FIELD("SURROUND_FLAT", dummy_level, surround_, DDFMainGetLumpName),
     DDF_FIELD("NEXT_MAP", dummy_level, next_mapname_, DDFMainGetLumpName),
@@ -288,22 +286,6 @@ void DDFLevelGetSpecials(const char *info)
     }
 }
 
-void DDFLevelGetSkyStretch(const char *info, void *storage)
-{
-    SkyStretch *stretch = (SkyStretch *)storage;
-
-    if (epi::StringCaseCompareASCII(info, "MIRROR") == 0)
-        *stretch = kSkyStretchMirror;
-    else if (epi::StringCaseCompareASCII(info, "REPEAT") == 0)
-        *stretch = kSkyStretchRepeat;
-    else if (epi::StringCaseCompareASCII(info, "STRETCH") == 0)
-        *stretch = kSkyStretchStretch;
-    else if (epi::StringCaseCompareASCII(info, "VANILLA") == 0)
-        *stretch = kSkyStretchVanilla;
-    else // Unknown
-        *stretch = kSkyStretchUnset;
-}
-
 static DDFSpecialFlags wistyle_names[] = {
     {"DOOM", kIntermissionStyleDoom, 0}, {"NONE", kIntermissionStyleNone, 0}, {nullptr, 0, 0}};
 
@@ -424,8 +406,6 @@ void MapDefinition::CopyDetail(MapDefinition &src)
     f_pre_ = src.f_pre_;
     f_end_ = src.f_end_;
 
-    forced_skystretch_ = src.forced_skystretch_;
-
     indoor_fog_cmap_     = src.indoor_fog_cmap_;
     indoor_fog_color_    = src.indoor_fog_color_;
     indoor_fog_density_  = src.indoor_fog_density_;
@@ -463,8 +443,6 @@ void MapDefinition::Default()
 
     f_pre_.Default();
     f_end_.Default();
-
-    forced_skystretch_ = kSkyStretchUnset;
 
     indoor_fog_cmap_     = nullptr;
     indoor_fog_color_    = kRGBANoValue;

--- a/source_files/ddf/ddf_level.h
+++ b/source_files/ddf/ddf_level.h
@@ -87,15 +87,6 @@ enum MapFlag
     kMapFlagTeamDamage   = (1 << 19),
 };
 
-enum SkyStretch
-{
-    kSkyStretchUnset   = -1,
-    kSkyStretchMirror  = 0,
-    kSkyStretchRepeat  = 1,
-    kSkyStretchStretch = 2,
-    kSkyStretchVanilla = 3,
-};
-
 enum IntermissionStyle
 {
     // standard Doom intermission stats
@@ -157,9 +148,6 @@ class MapDefinition
 
     // optional *MAPINFO field
     std::string author_;
-
-    // sky stretch override
-    SkyStretch forced_skystretch_;
 
     Colormap *indoor_fog_cmap_;
     RGBAColor indoor_fog_color_;

--- a/source_files/ddf/ddf_line.h
+++ b/source_files/ddf/ddf_line.h
@@ -133,67 +133,6 @@ enum AppearsFlag
     kAppearsWhenDefault     = 0xFFFF
 };
 
-enum ExtraFloorType
-{
-    kExtraFloorTypeNone = 0x0000,
-    // keeps the value from being zero
-    kExtraFloorTypePresent = 0x0001,
-    // floor is thick, has sides.  When clear: surface only
-    kExtraFloorTypeThick = 0x0002,
-    // floor is liquid, i.e. non-solid.  When clear: solid
-    kExtraFloorTypeLiquid = 0x0004,
-    // can monsters see through this extrafloor ?
-    kExtraFloorTypeSeeThrough = 0x0010,
-    // things with the WATERWALKER tag will not fall through.
-    // Also, certain player sounds (pain, death) can be overridden when
-    // in a water region.  Scope for other "waterish" effects...
-    kExtraFloorTypeWater = 0x0020,
-    // the region properties will "flood" all lower regions (unless it
-    // finds another flooder).
-    kExtraFloorTypeFlooder = 0x0040,
-    // the properties (lighting etc..) below are not transferred from
-    // the dummy sector, they'll be the same as the above region.
-    kExtraFloorTypeNoShade = 0x0080,
-    // take the side texture for THICK floors from the upper part of the
-    // sidedef where the thick floor is drawn (instead of tagging line).
-    kExtraFloorTypeSideUpper = 0x0100,
-    // like above, but use the lower part.
-    kExtraFloorTypeSideLower = 0x0200,
-    // this controls the Y offsets on normal THICK floors.
-    kExtraFloorTypeSideMidY = 0x0800,
-    // Boom compatibility flag (for linetype 242)
-    kExtraFloorTypeBoomTex = 0x1000
-};
-
-constexpr ExtraFloorType kExtraFloorThinDefaults   = ((ExtraFloorType)(kExtraFloorTypePresent | 0));
-constexpr ExtraFloorType kExtraFloorThickDefaults  = ((ExtraFloorType)(kExtraFloorTypePresent | kExtraFloorTypeThick));
-constexpr ExtraFloorType kExtraFloorLiquidDefaults = ((ExtraFloorType)(kExtraFloorTypePresent | kExtraFloorTypeLiquid));
-
-enum ExtraFloorControl
-{
-    // remove an extra floor
-    kExtraFloorControlNone = 0,
-    kExtraFloorControlRemove
-};
-
-class ExtraFloorDefinition
-{
-  public:
-    ExtraFloorDefinition();
-    ExtraFloorDefinition(ExtraFloorDefinition &rhs);
-    ~ExtraFloorDefinition();
-
-  private:
-    void Copy(ExtraFloorDefinition &src);
-
-  public:
-    void                  Default(void);
-    ExtraFloorDefinition &operator=(ExtraFloorDefinition &src);
-
-    ExtraFloorType    type_;
-    ExtraFloorControl control_;
-};
-
 class PlaneMoverDefinition
 {
   public:
@@ -530,17 +469,10 @@ enum SectorEffectType
     kSectorEffectTypeSetFriction  = (1 << 12),
     kSectorEffectTypeWindForce    = (1 << 13),
     kSectorEffectTypeCurrentForce = (1 << 14),
-    kSectorEffectTypePointForce   = (1 << 15),
+    kSectorEffectTypePointForce   = (1 << 15)
     // BOOM's linetype 242 -- deep water effect (etc)
-    kSectorEffectTypeBoomHeights = (1 << 16)
-};
-
-enum PortalEffectType
-{
-    kPortalEffectTypeNone     = 0,
-    kPortalEffectTypeStandard = (1 << 0),
-    kPortalEffectTypeMirror   = (1 << 1),
-    kPortalEffectTypeCamera   = (1 << 2),
+    // No longer needed - put relevant details directly in UDMF sector structure - Dasho
+    // kSectorEffectTypeBoomHeights = (1 << 16)
 };
 
 // -AJA- 2008/03/08: slope types
@@ -694,9 +626,6 @@ class LineType
     // Activation only possible from right side of line
     bool singlesided_;
 
-    // -AJA- 1999/06/21: Extra floor handling
-    ExtraFloorDefinition ef_;
-
     // -AJA- 1999/06/30: TRANSLUCENT MID-TEXTURES
     float translucency_;
 
@@ -712,12 +641,8 @@ class LineType
     BoomScrollerType scroll_type_;
 
     SectorEffectType sector_effect_;
-    PortalEffectType portal_effect_;
 
     SlopeType slope_type_;
-
-    // -AJA- 2007/07/05: color for effects (e.g. MIRRORs)
-    RGBAColor fx_color_;
 
   private:
     // disable copy construct and assignment operator
@@ -774,7 +699,10 @@ enum SectorFlag
     kSectorFlagAirLess = 0x0020,
 
     // player can swim in this sector
-    kSectorFlagSwimming = 0x0040
+    kSectorFlagSwimming = 0x0040,
+
+    // MUD: flag to mark when player is in deep water
+    kSectorFlagDeepWater = 0x0080,
 };
 
 class SectorType

--- a/source_files/edge/am_map.cc
+++ b/source_files/edge/am_map.cc
@@ -796,39 +796,6 @@ static void DrawGrid()
 }
 
 //
-// Checks whether the two sectors' regions are similiar.  If they are
-// different enough, a line will be drawn on the automap.
-//
-// -AJA- 1999/12/07: written.
-//
-static bool CheckSimiliarRegions(Sector *front, Sector *back)
-{
-    Extrafloor *F, *B;
-
-    if (front->tag == back->tag)
-        return true;
-
-    // Note: doesn't worry about liquids
-
-    F = front->bottom_extrafloor;
-    B = back->bottom_extrafloor;
-
-    while (F && B)
-    {
-        if (!AlmostEquals(F->top_height, B->top_height))
-            return false;
-
-        if (!AlmostEquals(F->bottom_height, B->bottom_height))
-            return false;
-
-        F = F->higher;
-        B = B->higher;
-    }
-
-    return (F || B) ? false : true;
-}
-
-//
 // Determines visible lines, draws them.
 //
 // -AJA- This is now *lineseg* based, not linedef.
@@ -967,12 +934,6 @@ static void AutomapWalkSeg(Seg *seg)
             {
                 // ceiling level change
                 DrawMLine(&l, am_colors[kAutomapColorCeil]);
-            }
-            else if ((front->extrafloor_used > 0 || back->extrafloor_used > 0) &&
-                     (front->extrafloor_used != back->extrafloor_used || !CheckSimiliarRegions(front, back)))
-            {
-                // -AJA- 1999/10/09: extra floor change.
-                DrawMLine(&l, am_colors[kAutomapColorLedge]);
             }
             else if (show_walls)
             {

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -70,18 +70,14 @@
 
 // Sound and Music
 #define EDGE_DEFAULT_SOUND_STEREO (1) // Stereo
-#define EDGE_DEFAULT_MIX_CHANNELS (2) // 32 channels
+#define EDGE_DEFAULT_MIX_CHANNELS (1) // 64 channels
 
 // Video Options
 #define EDGE_DEFAULT_USE_SMOOTHING (0)
-#define EDGE_DEFAULT_USE_DLIGHTS   (1)
-#define EDGE_DEFAULT_DETAIL_LEVEL  (2)
 #define EDGE_DEFAULT_SCREEN_HUD    (0)
 #define EDGE_DEFAULT_CROSSHAIR     (0)
 #define EDGE_DEFAULT_MAP_OVERLAY   (0)
 #define EDGE_DEFAULT_ROTATEMAP     (0)
-#define EDGE_DEFAULT_INVUL_FX      (1) // TEXTURED
-#define EDGE_DEFAULT_PNG_SCRSHOTS  (1)
 
 // Gameplay Options
 #define EDGE_DEFAULT_AUTOAIM        (0)

--- a/source_files/edge/dm_defs.h
+++ b/source_files/edge/dm_defs.h
@@ -279,7 +279,8 @@ enum LineFlag
 
     // ----- internal flags -----
 
-    kLineFlagMirror = (1 << 16),
+    // Unused now - Dasho
+    //kLineFlagMirror = (1 << 16),
 
     // -AJA- These two from XDoom.
     // Dasho - Moved to internal flag range to make room for MBF21 stuff

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -163,8 +163,6 @@ EDGE_DEFINE_CONSOLE_VARIABLE(team_name, "EDGE Team", kConsoleVariableFlagNoReset
 EDGE_DEFINE_CONSOLE_VARIABLE(application_name, "EDGE-Classic", kConsoleVariableFlagNoReset)
 EDGE_DEFINE_CONSOLE_VARIABLE(homepage, "https://edge-classic.github.io", kConsoleVariableFlagNoReset)
 
-EDGE_DEFINE_CONSOLE_VARIABLE_CLAMPED(title_scaling, "0", kConsoleVariableFlagArchive, 0, 1)
-
 EDGE_DEFINE_CONSOLE_VARIABLE(force_infighting, "0", kConsoleVariableFlagArchive)
 
 EDGE_DEFINE_CONSOLE_VARIABLE(ddf_strict, "0", kConsoleVariableFlagArchive)
@@ -215,8 +213,6 @@ class StartupProgress
         HUDFrameSetup();
         if (loading_image)
         {
-            if (title_scaling.d_) // Fill Border
-                HUDStretchImage(-320, -200, 960, 600, loading_image, 0, 0);
             HUDDrawImageTitleWS(loading_image);
             HUDSolidBox(25, 25, 295, 175, SG_BLACK_RGBA32);
         }
@@ -372,11 +368,6 @@ static void SetGlobalVariables(void)
 
     if (FindArgument("infight") > 0)
         force_infighting = 1;
-
-    if (FindArgument("dlights") > 0)
-        use_dynamic_lights = 1;
-    else if (FindArgument("nodlights") > 0)
-        use_dynamic_lights = 0;
 
     if (!global_flags.enemies_respawn)
     {
@@ -612,8 +603,6 @@ static void TitleDrawer(void)
 {
     if (title_image)
     {
-        if (title_scaling.d_) // Fill Border
-            HUDStretchImage(-320, -200, 960, 600, title_image, 0, 0);
         HUDDrawImageTitleWS(title_image);
     }
     else

--- a/source_files/edge/e_main.h
+++ b/source_files/edge/e_main.h
@@ -59,7 +59,5 @@ extern bool custom_MenuMain;
 extern bool custom_MenuEpisode;
 extern bool custom_MenuDifficulty;
 
-extern ConsoleVariable title_scaling;
-
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/edge/f_finale.cc
+++ b/source_files/edge/f_finale.cc
@@ -365,8 +365,6 @@ static void TextWrite(void)
         }
         else
         {
-            if (title_scaling.d_) // Fill Border
-                HUDStretchImage(-320, -200, 960, 600, finale_text_background, 0, 0);
             HUDDrawImageTitleWS(finale_text_background);
         }
 
@@ -700,8 +698,6 @@ static void CastDrawer(void)
     else
     {
         image = ImageLookup("BOSSBACK");
-        if (title_scaling.d_) // Fill Border
-            HUDStretchImage(-320, -200, 960, 600, image, 0, 0);
         HUDDrawImageTitleWS(image);
     }
 
@@ -880,8 +876,6 @@ void FinaleDrawer(void)
     case kFinaleStagePicture: {
         const Image *image =
             ImageLookup(finale->pics_[HMM_MIN((size_t)picture_number, finale->pics_.size() - 1)].c_str());
-        if (title_scaling.d_) // Fill Border
-            HUDStretchImage(-320, -200, 960, 600, image, 0, 0);
         HUDDrawImageTitleWS(image);
         break;
     }

--- a/source_files/edge/f_interm.cc
+++ b/source_files/edge/f_interm.cc
@@ -391,8 +391,6 @@ static void DrawLevelFinished(void)
             HUDTileImage(-240, 0, 820, 200, leaving_background_image);
         else
         {
-            if (title_scaling.d_) // Fill Border
-                HUDStretchImage(-320, -200, 960, 600, leaving_background_image, 0, 0);
             HUDDrawImageTitleWS(leaving_background_image);
         }
     }
@@ -556,8 +554,6 @@ static void DrawEnteringLevel(void)
             HUDTileImage(-240, 0, 820, 200, entering_background_image);
         else
         {
-            if (title_scaling.d_) // Fill Border
-                HUDStretchImage(-320, -200, 960, 600, entering_background_image, 0, 0);
             HUDDrawImageTitleWS(entering_background_image);
         }
     }
@@ -1796,8 +1792,6 @@ void IntermissionDrawer(void)
                              background_image); // Lobo: Widescreen support
             else
             {
-                if (title_scaling.d_) // Fill Border
-                    HUDStretchImage(-320, -200, 960, 600, background_image, 0, 0);
                 HUDDrawImageTitleWS(background_image);
             }
 

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -51,8 +51,6 @@ EDGE_DEFINE_CONSOLE_VARIABLE(pixel_aspect_ratio, "1.0", kConsoleVariableFlagRead
 EDGE_DEFINE_CONSOLE_VARIABLE(forced_pixel_aspect_ratio, "0", kConsoleVariableFlagArchive)
 
 extern ConsoleVariable renderer_far_clip;
-extern ConsoleVariable draw_culling;
-extern ConsoleVariable draw_culling_distance;
 
 void GrabCursor(bool enable)
 {
@@ -331,10 +329,7 @@ void StartFrame(void)
     ec_frame_stats.Clear();
     glClearColor(0, 0, 0, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    if (draw_culling.d_)
-        renderer_far_clip.f_ = draw_culling_distance.f_;
-    else
-        renderer_far_clip.f_ = 64000.0;
+    renderer_far_clip.f_ = 64000.0;
 }
 
 void FinishFrame(void)

--- a/source_files/edge/m_menu.cc
+++ b/source_files/edge/m_menu.cc
@@ -1440,49 +1440,10 @@ void MenuFinishReadThis(int choice)
     MenuSetupNextMenu(&MainMenuDefinition);
 }
 
-//
-// -KM- 1998/12/16 Handle sfx that don't exist in this version.
-// -KM- 1999/01/31 Generate quitsounds from default.ldf
-//
 static void QuitResponse(int ch)
 {
     if (ch != 'y' && ch != kGamepadA && ch != kMouse1)
         return;
-
-    if (!network_game)
-    {
-        int  numsounds = 0;
-        char refname[64];
-        int  i, start;
-
-        // Count the quit messages
-        do
-        {
-            sprintf(refname, "QuitSnd%d", numsounds + 1);
-            if (language.IsValidRef(refname))
-                numsounds++;
-            else
-                break;
-        } while (true);
-
-        if (numsounds)
-        {
-            // cycle through all the quit sounds, until one of them exists
-            // (some of the default quit sounds do not exist in DOOM 1)
-            start = i = RandomByte() % numsounds;
-            do
-            {
-                sprintf(refname, "QuitSnd%d", i + 1);
-                SoundEffect *quit_sound = sfxdefs.GetEffect(language[refname]);
-                if (quit_sound)
-                {
-                    StartSoundEffect(quit_sound);
-                    break;
-                }
-                i = (i + 1) % numsounds;
-            } while (i != start);
-        }
-    }
 
     // -ACB- 1999/09/20 New exit code order
     // Write the default config file first
@@ -1509,39 +1470,8 @@ static void QuitResponse(int ch)
 //
 void QuitEdge(int choice)
 {
-    char ref[64];
-
-    std::string msg;
-
-    int num_quitmessages = 0;
-
-    // Count the quit messages
-    do
-    {
-        num_quitmessages++;
-
-        sprintf(ref, "QUITMSG%d", num_quitmessages);
-    } while (language.IsValidRef(ref));
-
-    // we stopped at one higher than the last
-    num_quitmessages--;
-
-    // -ACB- 2004/08/14 Allow fallback to just the "PressToQuit" message
-    if (num_quitmessages > 0)
-    {
-        // Pick one at random
-        sprintf(ref, "QUITMSG%d", 1 + (RandomByte() % num_quitmessages));
-
-        // Construct the quit message in full
-        msg = epi::StringFormat("%s\n\n%s", language[ref], language["PressToQuit"]);
-    }
-    else
-    {
-        msg = std::string(language["PressToQuit"]);
-    }
-
     // Trigger the message
-    StartMenuMessage(msg.c_str(), QuitResponse, true);
+    StartMenuMessage(language["PressToQuit"], QuitResponse, true);
 }
 
 // Accessible from console's 'quit now' command
@@ -2827,10 +2757,7 @@ void MenuDrawer(void)
     if (menu_backdrop && (option_menu_on || network_game_menu_on ||
                           (current_menu->draw_function == MenuDrawLoad || current_menu->draw_function == MenuDrawSave)))
     {
-        if (title_scaling.d_) // Fill Border
-            HUDStretchImage(-320, -200, 960, 600, menu_backdrop, 0, 0);
-        else
-            HUDSolidBox(-320, -200, 960, 600, 0);
+        HUDSolidBox(-320, -200, 960, 600, 0);
         HUDDrawImageTitleWS(menu_backdrop);
     }
 

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -102,8 +102,6 @@ static ConfigurationDefault defaults[] = {
     {kConfigBoolean, "weaponkick", &global_flags.kicking, EDGE_DEFAULT_KICKING},
     {kConfigBoolean, "weaponswitch", &global_flags.weapon_switch, EDGE_DEFAULT_WEAPON_SWITCH},
     {kConfigInteger, "smoothing", &image_smoothing, EDGE_DEFAULT_USE_SMOOTHING},
-    {kConfigInteger, "dlights", &use_dynamic_lights, EDGE_DEFAULT_USE_DLIGHTS},
-    {kConfigInteger, "detail_level", &detail_level, EDGE_DEFAULT_DETAIL_LEVEL},
 
     // -KM- 1998/09/01 Useless mouse/joy stuff removed,
     //                 analogue binding added

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -1078,8 +1078,7 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
 
     if (source->player_)
         projz += (source->player_->view_z_ - source->player_->standard_view_height_);
-    else if (cur_source_sec->sink_depth > 0 && !cur_source_sec->extrafloor_used && !cur_source_sec->height_sector &&
-             abs(source->z - cur_source_sec->floor_height) < 1)
+    else if (cur_source_sec->sink_depth > 0 && abs(source->z - cur_source_sec->floor_height) < 1)
         projz -= (source->height_ * 0.5 * cur_source_sec->sink_depth);
 
     BAMAngle angle = source->angle_;
@@ -1156,7 +1155,7 @@ static MapObject *DoLaunchProjectile(MapObject *source, float tx, float ty, floa
 
         Sector *cur_target_sec = target->subsector_->sector;
 
-        if (cur_target_sec->sink_depth > 0 && !cur_target_sec->extrafloor_used && !cur_target_sec->height_sector &&
+        if (cur_target_sec->sink_depth > 0 &&
             abs(target->z - cur_target_sec->floor_height) < 1)
             tz -= (target->height_ * 0.5 * cur_target_sec->sink_depth);
     }

--- a/source_files/edge/p_blockmap.cc
+++ b/source_files/edge/p_blockmap.cc
@@ -79,11 +79,6 @@ static int dynamic_light_blockmap_height;
 
 MapObject **dynamic_light_blockmap_things = nullptr;
 
-extern std::unordered_set<AbstractShader *> seen_dynamic_lights;
-extern ConsoleVariable                      draw_culling;
-
-EDGE_DEFINE_CONSOLE_VARIABLE(max_dynamic_lights, "0", kConsoleVariableFlagArchive)
-
 void CreateThingBlockmap(void)
 {
     blockmap_things = new MapObject *[blockmap_width * blockmap_height];
@@ -836,9 +831,6 @@ void DynamicLightIterator(float x1, float y1, float z1, float x2, float y2, floa
                 if (mo->state_->bright <= 0 || mo->dynamic_light_.r <= 0)
                     continue;
 
-                if (draw_culling.d_ && PointToDistance(view_x, view_y, mo->x, mo->y) > renderer_far_clip.f_)
-                    continue;
-
                 // check whether radius touches the given bbox
                 float r = mo->dynamic_light_.r;
 
@@ -849,18 +841,6 @@ void DynamicLightIterator(float x1, float y1, float z1, float x2, float y2, floa
                 // create shader if necessary
                 if (!mo->dynamic_light_.shader)
                     mo->dynamic_light_.shader = MakeDLightShader(mo);
-
-                if (max_dynamic_lights.d_ > 0 && seen_dynamic_lights.count(mo->dynamic_light_.shader) == 0)
-                {
-                    if ((int)seen_dynamic_lights.size() >= max_dynamic_lights.d_ * 20)
-                        continue;
-                    else
-                    {
-                        seen_dynamic_lights.insert(mo->dynamic_light_.shader);
-                    }
-                }
-
-                //			mo->dynamic_light_.shader->CheckReset();
 
                 func(mo, data);
             }
@@ -879,9 +859,6 @@ void SectorGlowIterator(Sector *sec, float x1, float y1, float z1, float x2, flo
 
         // skip "off" lights
         if (mo->state_->bright <= 0 || mo->dynamic_light_.r <= 0)
-            continue;
-
-        if (draw_culling.d_ && PointToDistance(view_x, view_y, mo->x, mo->y) > renderer_far_clip.f_)
             continue;
 
         // check whether radius touches the given bbox

--- a/source_files/edge/p_forces.cc
+++ b/source_files/edge/p_forces.cc
@@ -58,25 +58,19 @@ static void WindCurrentForce(Force *f, MapObject *mo)
 
     Sector *sec = f->sector;
 
-    // NOTE: assumes that BOOM's [242] linetype was used
-    Extrafloor *ef = sec->bottom_liquid ? sec->bottom_liquid : sec->bottom_extrafloor;
-
     float qty = 0.5f;
 
     if (f->is_wind)
     {
-        if (ef && z2 < ef->bottom_height)
-            return;
-
-        if (z1 > (ef ? ef->bottom_height : sec->floor_height) + 2.0f)
+        if (z1 > sec->floor_height + 2.0f)
             qty = 1.0f;
     }
     else // Current
     {
-        if (z1 > (ef ? ef->bottom_height : sec->floor_height) + 2.0f)
+        if (z1 > sec->floor_height + 2.0f)
             return;
 
-        if (z2 < (ef ? ef->bottom_height : sec->ceiling_height))
+        if (z2 < sec->ceiling_height)
             qty = 1.0f;
     }
 

--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -169,22 +169,10 @@ int   FindThingGap(VerticalGap *gaps, int gap_num, float z1, float z2);
 void  ComputeGaps(Line *ld);
 float ComputeThingGap(MapObject *thing, Sector *sec, float z, float *f, float *c, float floor_slope_z = 0.0f,
                       float ceiling_slope_z = 0.0f);
-void  AddExtraFloor(Sector *sec, Line *line);
 void  RecomputeGapsAroundSector(Sector *sec);
-void  FloodExtraFloors(Sector *sector);
 
 bool CheckAreaForThings(float *bbox);
 bool CheckSliderPathForThings(Line *ld);
-
-enum ExtrafloorFit
-{
-    kFitOk = 0,
-    kFitStuckInCeiling,
-    kFitStuckInFloor,
-    kFitStuckInExtraFloor
-};
-
-ExtrafloorFit CheckExtrafloorFit(Sector *sec, float z1, float z2);
 
 //
 // P_MAP
@@ -211,7 +199,6 @@ bool       SolidSectorMove(Sector *sec, bool is_ceiling, float dh, int crush = 1
 bool       CheckAbsolutePosition(MapObject *thing, float x, float y, float z);
 bool       CheckSight(MapObject *src, MapObject *dest);
 bool       CheckSightToPoint(MapObject *src, float x, float y, float z);
-bool       QuickVerticalSightCheck(MapObject *src, MapObject *dest);
 void       RadiusAttack(MapObject *spot, MapObject *source, float radius, float damage, const DamageClass *damtype,
                         bool thrust_only);
 

--- a/source_files/edge/p_mobj.h
+++ b/source_files/edge/p_mobj.h
@@ -204,7 +204,7 @@ class MapObject : public Position
     // current subsector
     struct Subsector *subsector_ = nullptr;
 
-    // properties from extrafloor the thing is in
+    // properties from vertical region the thing is in (extrafloor only? - Dasho)
     struct RegionProperties *region_properties_ = nullptr;
 
     // Vert slope stuff maybe

--- a/source_files/edge/p_plane.cc
+++ b/source_files/edge/p_plane.cc
@@ -222,7 +222,7 @@ void DestroyAllSliders(void)
 //    RES_Ok - the move was completely successful.
 //
 //    RES_Impossible - the move was not possible due to another solid
-//    surface (e.g. an extrafloor) getting in the way.  The plane will
+//    surface getting in the way.  The plane will
 //    remain at its current height.
 //
 //    RES_PastDest - the destination height has been reached.  The

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -67,7 +67,7 @@ static void CalcHeight(Player *player, bool extra_tic)
     bool    onground  = player->map_object_->z <= player->map_object_->floor_z_;
     float   sink_mult = 1.0f;
     Sector *cur_sec   = player->map_object_->subsector_->sector;
-    if (!cur_sec->extrafloor_used && !cur_sec->height_sector && onground)
+    if (onground)
         sink_mult -= cur_sec->sink_depth;
 
     if (erraticism.d_ && level_time_elapsed > 0 && (!player->command_.forward_move && !player->command_.side_move) &&
@@ -725,7 +725,7 @@ bool PlayerThink(Player *player, bool extra_tic)
     {
         bool    sinking = false;
         Sector *cur_sec = player->map_object_->subsector_->sector;
-        if (!cur_sec->extrafloor_used && !cur_sec->height_sector && cur_sec->sink_depth > 0 &&
+        if (cur_sec->sink_depth > 0 &&
             player->map_object_->z <= player->map_object_->floor_z_)
             sinking = true;
         if (cmd->forward_move == 0 && cmd->side_move == 0 && !player->swimming_ && cmd->upward_move <= 0 &&
@@ -746,8 +746,8 @@ bool PlayerThink(Player *player, bool extra_tic)
         }
     }
 
-    if (player->map_object_->region_properties_->special ||
-        player->map_object_->subsector_->sector->extrafloor_used > 0 || player->underwater_ || player->swimming_ ||
+    if (player->map_object_->region_properties_->special || player->map_object_->subsector_->sector->has_deep_water ||
+        player->underwater_ || player->swimming_ ||
         player->airless_)
     {
         PlayerInSpecialSector(player, player->map_object_->subsector_->sector, should_think);

--- a/source_files/edge/r_colormap.cc
+++ b/source_files/edge/r_colormap.cc
@@ -162,7 +162,7 @@ class ColormapShader : public AbstractShader
 
   public:
     ColormapShader(const Colormap *CM)
-        : colormap_(CM), light_level_(255), fade_texture_(0), lighting_model_(kLightingModelDoom),
+        : colormap_(CM), light_level_(255), fade_texture_(0), lighting_model_(kLightingModelDoomish),
           fog_color_(kRGBANoValue), fog_density_(0), sector_(nullptr)
     {
     }

--- a/source_files/edge/r_defs.h
+++ b/source_files/edge/r_defs.h
@@ -151,54 +151,8 @@ struct MapSurface
     // lighting override (as in BOOM).  Usually nullptr.
     RegionProperties *override_properties;
 
-    // this only used for BOOM deep water (linetype 242)
-    const Colormap *boom_colormap;
-
     // used for fog boundaries if needed
     bool fog_wall = false;
-};
-
-//
-// ExtraFloor
-//
-// Stores information about a single extrafloor within a sector.
-//
-// -AJA- 2001/07/11: added this, replaces vert_region.
-//
-struct Extrafloor
-{
-    // links in chain.  These are sorted by increasing heights, using
-    // bottom_h as the reference.  This is important, especially when a
-    // liquid extrafloor overlaps a solid one: using this rule, the
-    // liquid region will be higher than the solid one.
-    struct Extrafloor *higher;
-    struct Extrafloor *lower;
-
-    struct Sector *sector;
-
-    // top and bottom heights of the extrafloor.  For non-THICK
-    // extrafloors, these are the same.  These are generally the same as
-    // in the dummy sector, EXCEPT during the process of moving the
-    // extrafloor.
-    float top_height, bottom_height;
-
-    // top/bottom surfaces of the extrafloor
-    MapSurface *top;
-    MapSurface *bottom;
-
-    // properties used for stuff below us
-    RegionProperties *properties;
-
-    // type of extrafloor this is.  Only nullptr for unused extrafloors.
-    // This value is cached pointer to extrafloor_line->special->ef.
-    const ExtraFloorDefinition *extrafloor_definition;
-
-    // extrafloor linedef (frontsector == control sector).  Only nullptr
-    // for unused extrafloors.
-    struct Line *extrafloor_line;
-
-    // link in dummy sector's controlling list
-    struct Extrafloor *control_sector_next;
 };
 
 // Vertical gap between a floor & a ceiling.
@@ -230,29 +184,7 @@ struct Sector
 
     int tag;
 
-    // set of extrafloors (in the global `extrafloors' array) that this
-    // sector can use.  At load time we can deduce the maximum number
-    // needed for extrafloors, even if they dynamically come and go.
-    //
-    short       extrafloor_maximum;
-    short       extrafloor_used;
-    Extrafloor *extrafloor_first;
-
-    // -AJA- 2001/07/11: New multiple extrafloor code.
-    //
-    // Now the FLOORS ARE IMPLIED.  Unlike before, the floor below an
-    // extrafloor is NOT stored in each extrafloor_t -- you must scan
-    // down to find them, and use the sector's floor if you hit nullptr.
-    Extrafloor *bottom_extrafloor;
-    Extrafloor *top_extrafloor;
-
-    // Liquid extrafloors are now kept in a separate list.  For many
-    // purposes (especially moving sectors) they otherwise just get in
-    // the way.
-    Extrafloor *bottom_liquid;
-    Extrafloor *top_liquid;
-
-    // properties that are active for this sector (top-most extrafloor).
+    // properties that are active for this sector
     // This may be different than the sector's actual properties (the
     // "props" field) due to flooders.
     RegionProperties *active_properties;
@@ -271,13 +203,12 @@ struct Sector
     HMM_Vec2              floor_vertex_slope_high_low;
     HMM_Vec2              ceiling_vertex_slope_high_low;
 
-    // linked list of extrafloors that this sector controls.  nullptr means
-    // that this sector is not a controller.
-    Extrafloor *control_floors;
-
-    // killough 3/7/98: support flat heights drawn at another sector's heights
-    struct Sector *height_sector;
-    struct Side   *height_sector_side;
+    // Dasho - Directly store our deep water - a simplified
+    // version of Boom heights - in the sector info via UDMF
+    bool has_deep_water;
+    MapSurface deep_water_surface;
+    RegionProperties deep_water_properties;
+    float deep_water_height;
 
     // movement thinkers, for quick look-up
     struct PlaneMover *floor_move;
@@ -434,8 +365,6 @@ struct Line
     // slider thinker, normally nullptr
     struct SlidingDoorMover *slider_move;
 
-    Line *portal_pair;
-
     bool old_stored = false;
 };
 
@@ -459,9 +388,6 @@ struct Subsector
 
     // pointer to bounding box (usually in parent node)
     float *bounding_box;
-
-    // -AJA- 2004/04/20: used when emulating deep-water TRICK
-    Sector *deep_water_reference;
 };
 
 //

--- a/source_files/edge/r_effects.cc
+++ b/source_files/edge/r_effects.cc
@@ -115,20 +115,14 @@ void RendererRainbowEffect(Player *player)
     }
 
     // AJA 2022: handle BOOM colormaps (linetype 242)
+    // Now sector deep_water - Dasho
     Sector *sector = player->map_object_->subsector_->sector;
 
-    if (sector->height_sector != nullptr)
+    if (sector->has_deep_water)
     {
         const Colormap *colmap = nullptr;
-
-        // see which region the camera is in
-        if (view_z > sector->height_sector->ceiling_height)
-            colmap = sector->height_sector_side->top.boom_colormap;
-        else if (view_z < sector->height_sector->floor_height)
-            colmap = sector->height_sector_side->bottom.boom_colormap;
-        else
-            colmap = sector->height_sector_side->middle.boom_colormap;
-
+        if (view_z < sector->deep_water_height)
+            colmap = sector->deep_water_properties.colourmap;
         render_view_effect_colormap = colmap;
     }
 }

--- a/source_files/edge/r_gldefs.h
+++ b/source_files/edge/r_gldefs.h
@@ -143,25 +143,12 @@ struct DrawFloor
 
     MapSurface *floor, *ceiling;
 
-    Extrafloor *extrafloor;
-
     // properties used herein
     RegionProperties *properties;
 
     // list of things
     // (not sorted until RenderFloor is called).
     DrawThing *things;
-};
-
-struct DrawMirror
-{
-    Seg *seg = nullptr;
-
-    BAMAngle left, right;
-
-    bool is_portal = false;
-
-    std::list<DrawSubsector *> draw_subsectors;
 };
 
 struct DrawSeg // HOPEFULLY this can go away
@@ -181,14 +168,10 @@ struct DrawSubsector
 
     std::list<DrawSeg *> segs;
 
-    std::list<DrawMirror *> mirrors;
-
     bool visible;
     bool sorted;
 };
 
-extern int detail_level;
-extern int use_dynamic_lights;
 extern int sprite_kludge;
 
 const Image *GetOtherSprite(int sprite, int frame, bool *flip);
@@ -204,21 +187,6 @@ DrawThing     *GetDrawThing();
 DrawFloor     *GetDrawFloor();
 DrawSeg       *GetDrawSeg();
 DrawSubsector *GetDrawSub();
-DrawMirror    *GetDrawMirror();
-
-//
-//  MIRRORS
-//
-
-extern int total_active_mirrors;
-
-void MirrorCoordinate(float &x, float &y);
-void MirrorHeight(float &z);
-void MirrorAngle(BAMAngle &ang);
-
-bool  MirrorReflective(void);
-float MirrorXYScale(void);
-float MirrorZScale(void);
 
 //--- editor settings ---
 // vi:ts=4:sw=4:noexpandtab

--- a/source_files/edge/r_image.cc
+++ b/source_files/edge/r_image.cc
@@ -602,12 +602,7 @@ static bool IM_ShouldSmooth(Image *rim)
 
 static int IM_PixelLimit(Image *rim)
 {
-    if (detail_level == 0)
-        return (1 << 18);
-    else if (detail_level == 1)
-        return (1 << 20);
-    else
-        return (1 << 22);
+     return (1 << 22);
 }
 
 static GLuint LoadImageOGL(Image *rim, bool do_whiten)

--- a/source_files/edge/r_main.cc
+++ b/source_files/edge/r_main.cc
@@ -30,15 +30,11 @@
 // implementation limits
 
 static int maximum_lights;
-static int maximum_clip_planes;
 static int maximum_texture_units;
 int        maximum_texture_size;
 
 EDGE_DEFINE_CONSOLE_VARIABLE(renderer_near_clip, "1", kConsoleVariableFlagArchive)
 EDGE_DEFINE_CONSOLE_VARIABLE(renderer_far_clip, "64000", kConsoleVariableFlagArchive)
-EDGE_DEFINE_CONSOLE_VARIABLE(draw_culling, "0", kConsoleVariableFlagArchive)
-EDGE_DEFINE_CONSOLE_VARIABLE_CLAMPED(draw_culling_distance, "3000", kConsoleVariableFlagArchive, 1000.0f, 16000.0f)
-EDGE_DEFINE_CONSOLE_VARIABLE(cull_fog_color, "0", kConsoleVariableFlagArchive)
 
 //
 // SetupMatrices2D
@@ -188,22 +184,19 @@ void RendererInit(void)
     // read implementation limits
     {
         GLint max_lights;
-        GLint max_clip_planes;
         GLint max_tex_size;
         GLint max_tex_units;
 
         glGetIntegerv(GL_MAX_LIGHTS, &max_lights);
-        glGetIntegerv(GL_MAX_CLIP_PLANES, &max_clip_planes);
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_tex_size);
         glGetIntegerv(GL_MAX_TEXTURE_UNITS, &max_tex_units);
 
         maximum_lights        = max_lights;
-        maximum_clip_planes   = max_clip_planes;
         maximum_texture_size  = max_tex_size;
         maximum_texture_units = max_tex_units;
     }
 
-    LogPrint("OpenGL: Lights: %d  Clips: %d  Tex: %d  Units: %d\n", maximum_lights, maximum_clip_planes,
+    LogPrint("OpenGL: Lights: %d  Clips: %d  Tex: %d  Units: %d\n", maximum_lights,
              maximum_texture_size, maximum_texture_units);
 
     RendererSoftInit();

--- a/source_files/edge/r_mdl.cc
+++ b/source_files/edge/r_mdl.cc
@@ -52,8 +52,6 @@
 
 extern float ApproximateDistance(float dx, float dy, float dz);
 
-extern ConsoleVariable draw_culling;
-extern ConsoleVariable cull_fog_color;
 extern bool            need_to_draw_sky;
 
 /*============== MDL FORMAT DEFINITIONS ====================*/
@@ -650,9 +648,6 @@ static inline void ModelCoordFunc(MDLCoordinateData *data, int v_idx, HMM_Vec3 *
     float y1 = LerpIt(vert1->y, vert2->y, data->lerp_);
     float z1 = LerpIt(vert1->z, vert2->z, data->lerp_) + data->bias_;
 
-    if (MirrorReflective())
-        y1 = -y1;
-
     data->CalculatePosition(pos, x1, y1, z1);
 
     const MDLVertex *n_vert = (data->lerp_ < 0.5) ? vert1 : vert2;
@@ -720,10 +715,7 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
     if (mo->hyper_flags_ & kHyperFlagNoZBufferUpdate)
         blending |= kBlendingNoZBuffer;
 
-    if (MirrorReflective())
-        blending |= kBlendingCullFront;
-    else
-        blending |= kBlendingCullBack;
+    blending |= kBlendingCullBack;
 
     data.map_object_ = mo;
     data.model_      = md;
@@ -739,8 +731,8 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
 
     data.is_weapon_ = is_weapon;
 
-    data.xy_scale_ = scale * aspect * MirrorXYScale();
-    data.z_scale_  = scale * MirrorZScale();
+    data.xy_scale_ = scale * aspect;
+    data.z_scale_  = scale;
     data.bias_     = bias;
 
     bool tilt = is_weapon || (mo->flags_ & kMapObjectFlagMissile) || (mo->hyper_flags_ & kHyperFlagForceModelTilt);
@@ -748,8 +740,6 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
     BAMAngleToMatrix(tilt ? ~mo->vertical_angle_ : 0, &data.mouselook_x_vector_, &data.mouselook_z_vector_);
 
     BAMAngle ang = mo->angle_ + rotation;
-
-    MirrorAngle(ang);
 
     BAMAngleToMatrix(~ang, &data.rotation_vector_x_, &data.rotation_vector_y_);
 
@@ -809,7 +799,7 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
 
         ShadeNormals(shader, &data, true);
 
-        if (use_dynamic_lights && render_view_extra_light < 250)
+        if (render_view_extra_light < 250)
         {
             float r = mo->radius_;
 
@@ -823,7 +813,7 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
 
     /* draw the model */
 
-    int num_pass = data.is_fuzzy_ ? 1 : (detail_level > 0 ? 4 : 3);
+    int num_pass = data.is_fuzzy_ ? 1 : 4;
 
     RGBAColor fc_to_use = mo->subsector_->sector->properties.fog_color;
     float     fd_to_use = mo->subsector_->sector->properties.fog_density;
@@ -841,7 +831,7 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
             fd_to_use = 0.01f * current_map->indoor_fog_density_;
         }
     }
-    if (!draw_culling.d_ && fc_to_use != kRGBANoValue)
+    if (fc_to_use != kRGBANoValue)
     {
         GLfloat fc[4];
         fc[0] = (float)epi::GetRGBARed(fc_to_use) / 255.0f;
@@ -849,45 +839,8 @@ void MDLRenderModel(MDLModel *md, const Image *skin_img, bool is_weapon, int fra
         fc[2] = (float)epi::GetRGBABlue(fc_to_use) / 255.0f;
         fc[3] = 1.0f;
         glClearColor(fc[0], fc[1], fc[2], 1.0f);
-        glFogi(GL_FOG_MODE, GL_EXP);
         glFogfv(GL_FOG_COLOR, fc);
         glFogf(GL_FOG_DENSITY, std::log1p(fd_to_use));
-        glEnable(GL_FOG);
-    }
-    else if (draw_culling.d_)
-    {
-        sg_color fogColor;
-        if (need_to_draw_sky)
-        {
-            switch (cull_fog_color.d_)
-            {
-            case 0:
-                fogColor = culling_fog_color;
-                break;
-            case 1:
-                // Not pure white, but 1.0f felt like a little much - Dasho
-                fogColor = sg_silver;
-                break;
-            case 2:
-                fogColor = {0.25f, 0.25f, 0.25f, 1.0f};
-                break;
-            case 3:
-                fogColor = sg_black;
-                break;
-            default:
-                fogColor = culling_fog_color;
-                break;
-            }
-        }
-        else
-        {
-            fogColor = sg_black;
-        }
-        glClearColor(fogColor.r, fogColor.g, fogColor.b, 1.0f);
-        glFogi(GL_FOG_MODE, GL_LINEAR);
-        glFogfv(GL_FOG_COLOR, &fogColor.r);
-        glFogf(GL_FOG_START, renderer_far_clip.f_ - 750.0f);
-        glFogf(GL_FOG_END, renderer_far_clip.f_ - 250.0f);
         glEnable(GL_FOG);
     }
     else

--- a/source_files/edge/r_misc.h
+++ b/source_files/edge/r_misc.h
@@ -75,7 +75,7 @@ extern float sine_table[kSineTableSize];
 
 //
 // Utility functions.
-BAMAngle          PointToAngle(float x1, float y1, float x2, float y2, bool precise = false);
+BAMAngle          PointToAngle(float x1, float y1, float x2, float y2);
 float             PointToDistance(float x1, float y1, float x2, float y2);
 Subsector        *PointInSubsector(float x, float y);
 RegionProperties *GetPointProperties(Subsector *sub, float z);

--- a/source_files/edge/r_shader.cc
+++ b/source_files/edge/r_shader.cc
@@ -171,9 +171,6 @@ class dynlight_shader_c : public AbstractShader
         float my = mo->y;
         float mz = MapObjectMidZ(mo);
 
-        MirrorCoordinate(mx, my);
-        MirrorHeight(mz);
-
         float dx = lit_pos->X - mx;
         float dy = lit_pos->Y - my;
         float dz = lit_pos->Z - mz;
@@ -212,9 +209,9 @@ class dynlight_shader_c : public AbstractShader
     inline float WhatRadius(int DL)
     {
         if (DL == 0)
-            return mo->dynamic_light_.r * MirrorXYScale();
+            return mo->dynamic_light_.r;
 
-        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_ * MirrorXYScale();
+        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_;
     }
 
     inline RGBAColor WhatColor(int DL)
@@ -233,9 +230,6 @@ class dynlight_shader_c : public AbstractShader
         float mx = mo->x;
         float my = mo->y;
         float mz = MapObjectMidZ(mo);
-
-        MirrorCoordinate(mx, my);
-        MirrorHeight(mz);
 
         float dx = x - mx;
         float dy = y - my;
@@ -274,15 +268,9 @@ class dynlight_shader_c : public AbstractShader
             my += view_sine * 24;
         }
 
-        MirrorCoordinate(mx, my);
-        MirrorHeight(mz);
-
         float dx = mod_pos->x;
         float dy = mod_pos->y;
         float dz = MapObjectMidZ(mod_pos);
-
-        MirrorCoordinate(dx, dy);
-        MirrorHeight(dz);
 
         dx -= mx;
         dy -= my;
@@ -294,7 +282,7 @@ class dynlight_shader_c : public AbstractShader
         dy /= dist;
         dz /= dist;
 
-        dist = HMM_MAX(1.0, dist - mod_pos->radius_ * MirrorXYScale());
+        dist = HMM_MAX(1.0, dist - mod_pos->radius_);
 
         float L = 0.6 - 0.7 * (dx * nx + dy * ny + dz * nz);
 
@@ -415,9 +403,9 @@ class plane_glow_c : public AbstractShader
     inline float WhatRadius(int DL)
     {
         if (DL == 0)
-            return mo->dynamic_light_.r * MirrorXYScale();
+            return mo->dynamic_light_.r;
 
-        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_ * MirrorXYScale();
+        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_;
     }
 
     inline RGBAColor WhatColor(int DL)
@@ -586,9 +574,9 @@ class wall_glow_c : public AbstractShader
     inline float WhatRadius(int DL)
     {
         if (DL == 0)
-            return mo->dynamic_light_.r * MirrorXYScale();
+            return mo->dynamic_light_.r;
 
-        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_ * MirrorXYScale();
+        return mo->info_->dlight_[1].radius_ * mo->dynamic_light_.r / mo->info_->dlight_[0].radius_ ;
     }
 
     inline RGBAColor WhatColor(int DL)

--- a/source_files/edge/r_state.h
+++ b/source_files/edge/r_state.h
@@ -47,9 +47,6 @@ extern Sector *level_sectors;
 extern int        total_level_subsectors;
 extern Subsector *level_subsectors;
 
-extern int         total_level_extrafloors;
-extern Extrafloor *level_extrafloors;
-
 extern int      total_level_nodes;
 extern BspNode *level_nodes;
 
@@ -233,18 +230,6 @@ class RenderState
         clear_blue_  = blue;
         clear_alpha_ = alpha;
         glClearColor(clear_red_, clear_green_, clear_blue_, clear_alpha_);
-        ec_frame_stats.draw_state_change++;
-    }
-
-    void FogMode(GLint fogMode)
-    {
-        if (fog_mode_ == fogMode)
-        {
-            return;
-        }
-
-        fog_mode_ = fogMode;
-        glFogi(GL_FOG_MODE, fog_mode_);
         ec_frame_stats.draw_state_change++;
     }
 
@@ -458,7 +443,7 @@ class RenderState
         ec_frame_stats.draw_state_change++;
 
         fog_mode_ = GL_LINEAR;
-        glFogi(GL_FOG_MODE, fog_mode_);
+        glFogi(GL_FOG_MODE, GL_EXP);
         ec_frame_stats.draw_state_change++;
 
         fog_color_[0] = 0.0f;

--- a/source_files/edge/r_texgl.cc
+++ b/source_files/edge/r_texgl.cc
@@ -131,7 +131,7 @@ GLuint UploadTexture(ImageData *img, int flags, int max_pix)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, smooth ? GL_LINEAR : GL_NEAREST);
 
     // minification mode
-    int mip_level = HMM_Clamp(0, detail_level, 2);
+    int mip_level = 2;
 
     // special logic for mid-masked textures.  The kUploadThresh flag
     // guarantees that each texture level has simple alpha (0 or 255),
@@ -160,7 +160,7 @@ GLuint UploadTexture(ImageData *img, int flags, int max_pix)
                      (img->depth_ == 3) ? GL_RGB : GL_RGBA, GL_UNSIGNED_BYTE, img->PixelAt(0, 0));
 
         // stop if mipmapping disabled or we have reached the end
-        if (nomip || !detail_level || (new_w == 1 && new_h == 1))
+        if (nomip || (new_w == 1 && new_h == 1))
             break;
 
         new_w = HMM_MAX(1, new_w / 2);

--- a/source_files/edge/r_units.h
+++ b/source_files/edge/r_units.h
@@ -41,8 +41,6 @@ struct RendererVertex
     HMM_Vec3 normal;
 };
 
-extern sg_color culling_fog_color;
-
 void StartUnitBatch(bool sort_em);
 void FinishUnitBatch(void);
 void RenderCurrentUnits(void);

--- a/source_files/epi/epi_known_enames.h
+++ b/source_files/epi/epi_known_enames.h
@@ -130,6 +130,10 @@ EPI_XX(Alphaceiling)
 EPI_XX(Rotationfloor)
 EPI_XX(Rotationceiling)
 EPI_XX(Gravity)
+EPI_XX(Liquidheight)
+EPI_XX(Liquidcolor)
+EPI_XX(Liquidtexture)
+EPI_XX(Liquidlight)
 
 // things
 EPI_XX(Height)


### PR DESCRIPTION
This PR moves us towards greatly simplified rendering and physics checks and also begins the removal of Doom-specific hacks or quirks that are no longer desired:
- Removal of portals and mirrors along with their associated clip planes and BSP checks
- Removal of support for the "flat flooding" hack
- Removal of support for 3D floors/extrafloors
- Removal of support for self-referencing linedef/sector hacks
- Removal of support for the 'goobers' cheat
- Removal of orthogonal wall faux shading
- Boom Heights (previously line 242) has been simplified to only support deep water and does not require a separate control sector in void space for reference
  - Deep water information is now directly added to the sector via UDMF
  - The following key/value pairs have been added to our namespace:
    - liquidheight = integer (defaults to 0)
    - liquidtexture = string (no default, must be defined for deep water to function)
    - liquidcolor = 0xRRGGBB (defaults to X11 Steel Blue)
    - liquidlightlevel = integer (defaults to 144)
- Removal of support for random quit sounds and messages upon exiting the program

In addition, some items that were previously menu options have either been hardcoded or relegated to config/CVAR-only manipulation. 
- Draw Distance Culling: Functionality removed
- Slow Thinkers Over Distance: Functionality removed
- Maximum Dynamic Lights: Functionality removed
- Detail Level (hardcoded to what was previously the 'High' setting)
- Texture Smoothing: Defaults to Off but can be adjusted via config text file
- Sky Stretch: Hardcoded to what was previously the 'Mirror' setting
- Title/Intermission scaling: Functionality removed
- Sound Channels: Defaults to 64 but can be adjusted via config file