### PR TITLE
Fix AnimationTicker()

### DIFF
--- a/source_files/edge/g_game.cc
+++ b/source_files/edge/g_game.cc
@@ -401,8 +401,6 @@ void GameTicker(void)
         default:
             break;
         }
-        // ANIMATE FLATS AND TEXTURES GLOBALLY
-        AnimationTicker();
         return;
     }
 

--- a/source_files/edge/r_image.cc
+++ b/source_files/edge/r_image.cc
@@ -138,7 +138,7 @@ static void do_Animate(std::list<Image *> &bucket)
 
         EPI_ASSERT(rim->animation_.count > 0);
 
-        rim->animation_.count -= (!double_framerate.d_) ? 1 : 0;
+        rim->animation_.count--;
 
         if (rim->animation_.count == 0 && rim->animation_.current->animation_.next)
         {


### PR DESCRIPTION
This fixes AnimationTicker, which previously worked off of a now-removed variable called hud_tic. It also only run on "real tics" now, instead of extra rendering tics. I believe in the past it may have run on both when swirling flats were a thing.