### PR TITLE
Disable GL fog; remove "fogwall" concept for sector fog boundaries

### DIFF
--- a/source_files/ddf/ddf_level.cc
+++ b/source_files/ddf/ddf_level.cc
@@ -77,10 +77,10 @@ static const DDFCommandList level_commands[] = {
     DDF_FIELD("STATS", dummy_level, wistyle_, DDFLevelGetWistyle),
     DDF_FIELD("LEAVING_BACKGROUND", dummy_level, leavingbggraphic_, DDFMainGetLumpName),
     DDF_FIELD("ENTERING_BACKGROUND", dummy_level, enteringbggraphic_, DDFMainGetLumpName),
-    DDF_FIELD("INDOOR_FOG_COLOR", dummy_level, indoor_fog_cmap_, DDFMainGetColourmap),
-    DDF_FIELD("INDOOR_FOG_DENSITY", dummy_level, indoor_fog_density_, DDFMainGetPercent),
-    DDF_FIELD("OUTDOOR_FOG_COLOR", dummy_level, outdoor_fog_cmap_, DDFMainGetColourmap),
-    DDF_FIELD("OUTDOOR_FOG_DENSITY", dummy_level, outdoor_fog_density_, DDFMainGetPercent),
+    //DDF_FIELD("INDOOR_FOG_COLOR", dummy_level, indoor_fog_cmap_, DDFMainGetColourmap),
+    //DDF_FIELD("INDOOR_FOG_DENSITY", dummy_level, indoor_fog_density_, DDFMainGetPercent),
+    //DDF_FIELD("OUTDOOR_FOG_COLOR", dummy_level, outdoor_fog_cmap_, DDFMainGetColourmap),
+    //DDF_FIELD("OUTDOOR_FOG_DENSITY", dummy_level, outdoor_fog_density_, DDFMainGetPercent),
 
     {nullptr, nullptr, 0, nullptr}};
 
@@ -182,11 +182,11 @@ static void LevelFinishEntry(void)
     if (dynamic_level->episode_name_.empty())
         DDFError("Level entry must have an EPISODE name!\n");
 
-    if (dynamic_level->indoor_fog_cmap_)
+    /*if (dynamic_level->indoor_fog_cmap_)
         dynamic_level->indoor_fog_color_ = dynamic_level->indoor_fog_cmap_->gl_color_;
 
     if (dynamic_level->outdoor_fog_cmap_)
-        dynamic_level->outdoor_fog_color_ = dynamic_level->outdoor_fog_cmap_->gl_color_;
+        dynamic_level->outdoor_fog_color_ = dynamic_level->outdoor_fog_cmap_->gl_color_;*/
 }
 
 static void LevelClearAll(void)
@@ -407,12 +407,12 @@ void MapDefinition::CopyDetail(MapDefinition &src)
     f_pre_ = src.f_pre_;
     f_end_ = src.f_end_;
 
-    indoor_fog_cmap_     = src.indoor_fog_cmap_;
+    /*indoor_fog_cmap_     = src.indoor_fog_cmap_;
     indoor_fog_color_    = src.indoor_fog_color_;
     indoor_fog_density_  = src.indoor_fog_density_;
     outdoor_fog_cmap_    = src.outdoor_fog_cmap_;
     outdoor_fog_color_   = src.outdoor_fog_color_;
-    outdoor_fog_density_ = src.outdoor_fog_density_;
+    outdoor_fog_density_ = src.outdoor_fog_density_;*/
 }
 
 void MapDefinition::Default()
@@ -445,12 +445,12 @@ void MapDefinition::Default()
     f_pre_.Default();
     f_end_.Default();
 
-    indoor_fog_cmap_     = nullptr;
+    /*indoor_fog_cmap_     = nullptr;
     indoor_fog_color_    = kRGBANoValue;
     indoor_fog_density_  = 0;
     outdoor_fog_cmap_    = nullptr;
     outdoor_fog_color_   = kRGBANoValue;
-    outdoor_fog_density_ = 0;
+    outdoor_fog_density_ = 0;*/
 }
 
 //

--- a/source_files/ddf/ddf_level.h
+++ b/source_files/ddf/ddf_level.h
@@ -149,12 +149,12 @@ class MapDefinition
     // optional *MAPINFO field
     std::string author_;
 
-    Colormap *indoor_fog_cmap_;
-    RGBAColor indoor_fog_color_;
-    float     indoor_fog_density_;
-    Colormap *outdoor_fog_cmap_;
-    RGBAColor outdoor_fog_color_;
-    float     outdoor_fog_density_;
+    //Colormap *indoor_fog_cmap_;
+    //RGBAColor indoor_fog_color_;
+    //float     indoor_fog_density_;
+    //Colormap *outdoor_fog_cmap_;
+    //RGBAColor outdoor_fog_color_;
+    //float     outdoor_fog_density_;
 
   private:
     // disable copy construct and assignment operator

--- a/source_files/ddf/ddf_line.h
+++ b/source_files/ddf/ddf_line.h
@@ -720,9 +720,9 @@ class SectorType
     float floor_bob_;
     float ceiling_bob_;
 
-    Colormap *fog_cmap_;
+    /*Colormap *fog_cmap_;
     RGBAColor fog_color_;
-    float     fog_density_;
+    float     fog_density_;*/
 
   private:
     // disable copy construct and assignment operator

--- a/source_files/ddf/ddf_sector.cc
+++ b/source_files/ddf/ddf_sector.cc
@@ -74,8 +74,8 @@ static const DDFCommandList sect_commands[] = {
     DDF_FIELD("FLOOR_BOB", dummy_sector, floor_bob_, DDFMainGetFloat),
     DDF_FIELD("CEILING_BOB", dummy_sector, ceiling_bob_, DDFMainGetFloat),
 
-    DDF_FIELD("FOG_COLOR", dummy_sector, fog_cmap_, DDFMainGetColourmap),
-    DDF_FIELD("FOG_DENSITY", dummy_sector, fog_density_, DDFMainGetPercent),
+    //DDF_FIELD("FOG_COLOR", dummy_sector, fog_cmap_, DDFMainGetColourmap),
+    //DDF_FIELD("FOG_DENSITY", dummy_sector, fog_density_, DDFMainGetPercent),
 
     {nullptr, nullptr, 0, nullptr}};
 
@@ -163,8 +163,8 @@ static void SectorParseField(const char *field, const char *contents, int index,
 //
 static void SectorFinishEntry(void)
 {
-    if (dynamic_sector->fog_cmap_)
-        dynamic_sector->fog_color_ = dynamic_sector->fog_cmap_->gl_color_;
+    //if (dynamic_sector->fog_cmap_)
+        //dynamic_sector->fog_color_ = dynamic_sector->fog_cmap_->gl_color_;
 }
 
 //
@@ -478,9 +478,9 @@ void SectorType::CopyDetail(SectorType &src)
     floor_bob_   = src.floor_bob_;
     ceiling_bob_ = src.ceiling_bob_;
 
-    fog_cmap_    = src.fog_cmap_;
+    /*fog_cmap_    = src.fog_cmap_;
     fog_color_   = src.fog_color_;
-    fog_density_ = src.fog_density_;
+    fog_density_ = src.fog_density_;*/
 }
 
 void SectorType::Default()
@@ -516,9 +516,9 @@ void SectorType::Default()
     floor_bob_   = 0.0f;
     ceiling_bob_ = 0.0f;
 
-    fog_cmap_    = nullptr;
+    /*fog_cmap_    = nullptr;
     fog_color_   = kRGBANoValue;
-    fog_density_ = 0;
+    fog_density_ = 0;*/
 }
 
 SectorTypeContainer::SectorTypeContainer()

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -890,10 +890,10 @@ static void LoadUDMFSectors()
             float     gravfactor = 1.0f;
             int       light = 160, liquid_light = 144, type = 0, tag = 0;
             float     liquid_trans = 0.5f;
-            RGBAColor fog_color   = SG_BLACK_RGBA32;
+            //RGBAColor fog_color   = SG_BLACK_RGBA32;
             RGBAColor light_color = SG_WHITE_RGBA32;
             RGBAColor liquid_color = SG_STEEL_BLUE_RGBA32;
-            int       fog_density = 0;
+            //int       fog_density = 0;
             char      floor_tex[10];
             char      ceil_tex[10];
             char      liquid_tex[10];
@@ -954,12 +954,12 @@ static void LoadUDMFSectors()
                 case epi::kENameLightcolor:
                     light_color = ((uint32_t)epi::LexInteger(value) << 8 | 0xFF);
                     break;
-                case epi::kENameFadecolor:
+                /*case epi::kENameFadecolor:
                     fog_color = ((uint32_t)epi::LexInteger(value) << 8 | 0xFF);
                     break;
                 case epi::kENameFogdensity:
                     fog_density = HMM_Clamp(0, epi::LexInteger(value), 1020);
-                    break;
+                    break;*/
                 case epi::kENameXpanningfloor:
                     fx = epi::LexDouble(value);
                     break;
@@ -1094,7 +1094,7 @@ static void LoadUDMFSectors()
             ss->properties.drag      = kDragDefault;
 
             // Allow UDMF sector light/fog information to override DDFSECT types
-            if (fog_color != SG_BLACK_RGBA32) // All black is the established
+            /*if (fog_color != SG_BLACK_RGBA32) // All black is the established
                                               // UDMF "no fog" color
             {
                 // Prevent UDMF-specified fog color from having our internal 'no
@@ -1118,7 +1118,7 @@ static void LoadUDMFSectors()
             {
                 ss->properties.fog_color   = kRGBANoValue;
                 ss->properties.fog_density = 0;
-            }
+            }*/
             if (light_color != SG_WHITE_RGBA32)
             {
                 if (light_color == kRGBANoValue)

--- a/source_files/edge/r_colormap.cc
+++ b/source_files/edge/r_colormap.cc
@@ -218,7 +218,7 @@ class ColormapShader : public AbstractShader
     virtual void WorldMix(GLuint shape, int num_vert, GLuint tex, float alpha, int *pass_var, int blending, bool masked,
                           void *data, ShaderCoordinateFunction func)
     {
-        RGBAColor fc_to_use = fog_color_;
+        /*RGBAColor fc_to_use = fog_color_;
         float     fd_to_use = fog_density_;
         // check for DDFLEVL fog
         if (fc_to_use == kRGBANoValue)
@@ -233,7 +233,10 @@ class ColormapShader : public AbstractShader
                 fc_to_use = current_map->indoor_fog_color_;
                 fd_to_use = 0.01f * current_map->indoor_fog_density_;
             }
-        }
+        }*/
+
+       RGBAColor fc_to_use = kRGBANoValue;
+       float fd_to_use = 0;
 
         RendererVertex *glvert = BeginRenderUnit(shape, num_vert, GL_MODULATE, tex, GL_MODULATE, fade_texture_,
                                                    *pass_var, blending, fc_to_use, fd_to_use);
@@ -359,11 +362,11 @@ class ColormapShader : public AbstractShader
         light_level_ = level;
     }
 
-    void SetFog(RGBAColor fog_color, float fog_density)
+    /*void SetFog(RGBAColor fog_color, float fog_density)
     {
         fog_color_   = fog_color;
         fog_density_ = fog_density;
-    }
+    }*/
 
     void SetSector(Sector *sec)
     {
@@ -409,7 +412,7 @@ AbstractShader *GetColormapShader(const struct RegionProperties *props, int ligh
 
     shader->SetLight(lit_Nom);
 
-    shader->SetFog(props->fog_color, props->fog_density);
+    //shader->SetFog(props->fog_color, props->fog_density);
 
     shader->SetSector(sec);
 

--- a/source_files/edge/r_defs.h
+++ b/source_files/edge/r_defs.h
@@ -112,8 +112,8 @@ struct RegionProperties
     HMM_Vec3 old_push = {{0, 0, 0}};
 
     // sector fog
-    RGBAColor fog_color   = kRGBANoValue;
-    float     fog_density = 0;
+    //RGBAColor fog_color   = kRGBANoValue;
+    //float     fog_density = 0;
 };
 
 //
@@ -150,9 +150,6 @@ struct MapSurface
 
     // lighting override (as in BOOM).  Usually nullptr.
     RegionProperties *override_properties;
-
-    // used for fog boundaries if needed
-    bool fog_wall = false;
 };
 
 // Vertical gap between a floor & a ceiling.

--- a/source_files/edge/r_image.cc
+++ b/source_files/edge/r_image.cc
@@ -835,21 +835,6 @@ const Image *ImageForHomDetect(void)
     return dummy_hom[(render_frame_count & 0x10) ? 1 : 0];
 }
 
-const Image *ImageForFogWall(RGBAColor fog_color)
-{
-    std::string fogname = epi::StringFormat("FOGWALL_%d", fog_color);
-    Image      *fogwall = (Image *)ImageLookup(fogname.c_str(), kImageNamespaceGraphic, kImageLookupNull);
-    if (fogwall)
-        return fogwall;
-    ImageDefinition *fogdef = new ImageDefinition;
-    fogdef->colour_         = fog_color;
-    fogdef->name_           = fogname;
-    fogdef->type_           = kImageDataColor;
-    fogdef->belong_         = kImageNamespaceGraphic;
-    fogwall                 = AddImageUser(fogdef);
-    return fogwall;
-}
-
 //----------------------------------------------------------------------------
 //
 //  IMAGE USAGE

--- a/source_files/edge/r_image.h
+++ b/source_files/edge/r_image.h
@@ -205,7 +205,6 @@ const Image *ImageLookup(const char *name, ImageNamespace = kImageNamespaceGraph
 const Image *ImageForDummySprite(void);
 const Image *ImageForDummySkin(void);
 const Image *ImageForHomDetect(void);
-const Image *ImageForFogWall(RGBAColor fog_color);
 
 //
 //  IMAGE USAGE

--- a/source_files/edge/r_main.cc
+++ b/source_files/edge/r_main.cc
@@ -168,7 +168,7 @@ void RendererSoftInit(void)
     glCullFace(GL_BACK);
     glDisable(GL_CULL_FACE);
 
-    glHint(GL_FOG_HINT, GL_NICEST);
+    //glHint(GL_FOG_HINT, GL_NICEST);
     glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 }
 

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -813,7 +813,7 @@ static void ComputeWallTiles(Seg *seg, DrawFloor *dfloor, int sidenum, float f_m
 
     float slope_ch = sec->ceiling_height;
 
-    RGBAColor sec_fc = sec->properties.fog_color;
+    /*RGBAColor sec_fc = sec->properties.fog_color;
     float     sec_fd = sec->properties.fog_density;
     // check for DDFLEVL fog
     if (sec_fc == kRGBANoValue)
@@ -846,27 +846,12 @@ static void ComputeWallTiles(Seg *seg, DrawFloor *dfloor, int sidenum, float f_m
                 other_fd = 0.01f * current_map->indoor_fog_density_;
             }
         }
-    }
+    }*/
 
-    if (!sd->middle.image)
-    {
-        if (sec_fc == kRGBANoValue && other_fc != kRGBANoValue)
-        {
-            Image *fw               = (Image *)ImageForFogWall(other_fc);
-            fw->opacity_            = kOpacityComplex;
-            sd->middle.image        = fw;
-            sd->middle.translucency = other_fd * 100;
-            sd->middle.fog_wall     = true;
-        }
-        else if (sec_fc != kRGBANoValue && other_fc != sec_fc)
-        {
-            Image *fw               = (Image *)ImageForFogWall(sec_fc);
-            fw->opacity_            = kOpacityComplex;
-            sd->middle.image        = fw;
-            sd->middle.translucency = sec_fd * 100;
-            sd->middle.fog_wall     = true;
-        }
-    }
+    RGBAColor sec_fc = kRGBANoValue;
+    float     sec_fd = 0;
+    RGBAColor other_fc = kRGBANoValue;
+    float     other_fd = 0;
 
     if (!other)
     {
@@ -960,14 +945,7 @@ static void ComputeWallTiles(Seg *seg, DrawFloor *dfloor, int sidenum, float f_m
 
         float f2, c2;
 
-        if (sd->middle.fog_wall)
-        {
-            float ofh = other->floor_height;
-            f2 = f1   = HMM_MAX(HMM_MIN(sec->floor_height, slope_fh), ofh);
-            float och = other->ceiling_height;
-            c2 = c1 = HMM_MIN(HMM_MAX(sec->ceiling_height, slope_ch), och);
-        }
-        else if (ld->flags & kLineFlagLowerUnpegged)
+        if (ld->flags & kLineFlagLowerUnpegged)
         {
             f2 = f1 + sd->middle_mask_offset;
             c2 = f2 + (sd->middle.image->ScaledHeightActual() / sd->middle.y_matrix.Y);

--- a/source_files/edge/r_shader.cc
+++ b/source_files/edge/r_shader.cc
@@ -280,8 +280,8 @@ class dynlight_shader_c : public AbstractShader
                                   : is_additive           ? (GLuint)kTextureEnvironmentDisable
                                                           : GL_MODULATE,
                                   (is_additive && !masked) ? 0 : tex, GL_MODULATE, lim[DL]->TextureId(), *pass_var,
-                                  blending, *pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
-                                  mo->subsector_->sector->properties.fog_density);
+                                  blending, kRGBANoValue, 0/**pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
+                                  mo->subsector_->sector->properties.fog_density*/);
 
             for (int v_idx = 0; v_idx < num_vert; v_idx++)
             {
@@ -421,8 +421,8 @@ class plane_glow_c : public AbstractShader
                                   : is_additive           ? (GLuint)kTextureEnvironmentDisable
                                                           : GL_MODULATE,
                                   (is_additive && !masked) ? 0 : tex, GL_MODULATE, lim[DL]->TextureId(), *pass_var,
-                                  blending, *pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
-                                  mo->subsector_->sector->properties.fog_density);
+                                  blending, kRGBANoValue, 0/**pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
+                                  mo->subsector_->sector->properties.fog_density*/);
 
             for (int v_idx = 0; v_idx < num_vert; v_idx++)
             {
@@ -563,8 +563,8 @@ class wall_glow_c : public AbstractShader
                                   : is_additive           ? (GLuint)kTextureEnvironmentDisable
                                                           : GL_MODULATE,
                                   (is_additive && !masked) ? 0 : tex, GL_MODULATE, lim[DL]->TextureId(), *pass_var,
-                                  blending, *pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
-                                  mo->subsector_->sector->properties.fog_density);
+                                  blending, kRGBANoValue, 0/**pass_var > 0 ? kRGBANoValue : mo->subsector_->sector->properties.fog_color,
+                                  mo->subsector_->sector->properties.fog_density*/);
 
             for (int v_idx = 0; v_idx < num_vert; v_idx++)
             {

--- a/source_files/edge/r_sky.cc
+++ b/source_files/edge/r_sky.cc
@@ -379,7 +379,7 @@ static void RenderSkyCylinder(void)
     solid_sky_h = sky_h_ratio * 0.75f;
     float cap_z = dist * sky_h_ratio;
 
-    RGBAColor fc_to_use = current_map->outdoor_fog_color_;
+    /*RGBAColor fc_to_use = current_map->outdoor_fog_color_;
     float     fd_to_use = 0.01f * current_map->outdoor_fog_density_;
     // check for sector fog
     if (fc_to_use == kRGBANoValue)
@@ -395,7 +395,7 @@ static void RenderSkyCylinder(void)
         glFogfv(GL_FOG_COLOR, &fc.r);
         glFogf(GL_FOG_DENSITY, std::log1p(fd_to_use * 0.005f));
         glEnable(GL_FOG);
-    }
+    }*/
 
     // Render top cap
     glColor4f(sky_cap_color.r, sky_cap_color.g, sky_cap_color.b, 1.0f);
@@ -452,7 +452,7 @@ static void RenderSkyCylinder(void)
 
     glDisable(GL_BLEND);
     glDisable(GL_ALPHA_TEST);
-    glDisable(GL_FOG);
+    //glDisable(GL_FOG);
 
     RendererRevertSkyMatrices();
 }
@@ -489,7 +489,7 @@ static void RenderSkybox(void)
 
     glColor4fv(col);
 
-    RGBAColor fc_to_use = current_map->outdoor_fog_color_;
+    /*RGBAColor fc_to_use = current_map->outdoor_fog_color_;
     float     fd_to_use = 0.01f * current_map->outdoor_fog_density_;
     // check for sector fog
     if (fc_to_use == kRGBANoValue)
@@ -505,7 +505,7 @@ static void RenderSkybox(void)
         glFogfv(GL_FOG_COLOR, &fc.r);
         glFogf(GL_FOG_DENSITY, std::log1p(fd_to_use * 0.01f));
         glEnable(GL_FOG);
-    }
+    }*/
 
     // top
     glBindTexture(GL_TEXTURE_2D, fake_box[SK].texture[kSkyboxTop]);
@@ -616,7 +616,7 @@ static void RenderSkybox(void)
     glEnd();
 
     glDisable(GL_TEXTURE_2D);
-    glDisable(GL_FOG);
+    //glDisable(GL_FOG);
 
     RendererRevertSkyMatrices();
 }

--- a/source_files/edge/r_state.h
+++ b/source_files/edge/r_state.h
@@ -94,11 +94,11 @@ class RenderState
                 return;
             enable_texture_2d_[active_texture_ - GL_TEXTURE0] = enabled;
             break;
-        case GL_FOG:
+        /*case GL_FOG:
             if (enable_fog_ == enabled)
                 return;
             enable_fog_ = enabled;
-            break;
+            break;*/
         case GL_ALPHA_TEST:
             if (enable_alpha_test_ == enabled)
                 return;
@@ -233,7 +233,7 @@ class RenderState
         ec_frame_stats.draw_state_change++;
     }
 
-    void FogColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
+    /*void FogColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
     {
         if (AlmostEquals(red, fog_color_[0]) && AlmostEquals(green, fog_color_[1]) &&
             AlmostEquals(blue, fog_color_[2]) && AlmostEquals(alpha, fog_color_[3]))
@@ -284,7 +284,7 @@ class RenderState
         fog_density_ = density;
         glFogf(GL_FOG_DENSITY, fog_density_);
         ec_frame_stats.draw_state_change++;
-    }
+    }*/
 
     void BlendFunction(GLenum sfactor, GLenum dfactor)
     {
@@ -367,7 +367,7 @@ class RenderState
         CullFace(GL_BACK);
         Disable(GL_CULL_FACE);
 
-        Disable(GL_FOG);
+        //Disable(GL_FOG);
 
         PolygonOffset(0, 0);
 
@@ -442,7 +442,7 @@ class RenderState
         glClearColor(clear_red_, clear_green_, clear_blue_, clear_alpha_);
         ec_frame_stats.draw_state_change++;
 
-        fog_mode_ = GL_LINEAR;
+        /*fog_mode_ = GL_LINEAR;
         glFogi(GL_FOG_MODE, GL_EXP);
         ec_frame_stats.draw_state_change++;
 
@@ -465,7 +465,7 @@ class RenderState
 
         fog_density_ = 0.0f;
         glFogf(GL_FOG_DENSITY, fog_density_);
-        ec_frame_stats.draw_state_change++;
+        ec_frame_stats.draw_state_change++;*/
 
         polygon_offset_factor_ = 0;
         polygon_offset_units_  = 0;
@@ -514,12 +514,12 @@ class RenderState
     GLenum  alpha_function_;
     GLfloat alpha_function_reference_;
 
-    bool    enable_fog_;
+    /*bool    enable_fog_;
     GLint   fog_mode_;
     GLfloat fog_start_;
     GLfloat fog_end_;
     GLfloat fog_density_;
-    GLfloat fog_color_[4];
+    GLfloat fog_color_[4];*/
 };
 
 RenderState *GetRenderState();

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -252,7 +252,7 @@ static void RenderPSprite(PlayerSprite *psp, int which, Player *player, RegionPr
         trans    = 1.0f;
     }
 
-    RGBAColor fc_to_use = player->map_object_->subsector_->sector->properties.fog_color;
+    /*RGBAColor fc_to_use = player->map_object_->subsector_->sector->properties.fog_color;
     float     fd_to_use = player->map_object_->subsector_->sector->properties.fog_density;
     // check for DDFLEVL fog
     if (fc_to_use == kRGBANoValue)
@@ -267,7 +267,10 @@ static void RenderPSprite(PlayerSprite *psp, int which, Player *player, RegionPr
             fc_to_use = current_map->indoor_fog_color_;
             fd_to_use = 0.01f * current_map->indoor_fog_density_;
         }
-    }
+    }*/
+
+   RGBAColor fc_to_use = kRGBANoValue;
+   float fd_to_use = 0;
 
     if (!is_fuzzy)
     {
@@ -1048,7 +1051,7 @@ void RenderThing(DrawFloor *dfloor, DrawThing *dthing)
 
     int num_pass = is_fuzzy ? 1 : 4;
 
-    RGBAColor fc_to_use = dthing->map_object->subsector_->sector->properties.fog_color;
+    /*RGBAColor fc_to_use = dthing->map_object->subsector_->sector->properties.fog_color;
     float     fd_to_use = dthing->map_object->subsector_->sector->properties.fog_density;
     // check for DDFLEVL fog
     if (fc_to_use == kRGBANoValue)
@@ -1063,7 +1066,10 @@ void RenderThing(DrawFloor *dfloor, DrawThing *dthing)
             fc_to_use = current_map->indoor_fog_color_;
             fd_to_use = 0.01f * current_map->indoor_fog_density_;
         }
-    }
+    }*/
+
+    RGBAColor fc_to_use = kRGBANoValue;
+    float fd_to_use = 0;
 
     for (int pass = 0; pass < num_pass; pass++)
     {

--- a/source_files/edge/r_units.cc
+++ b/source_files/edge/r_units.cc
@@ -278,8 +278,8 @@ void RenderCurrentUnits(void)
     int active_pass     = 0;
     int active_blending = 0;
 
-    RGBAColor active_fog_rgb     = kRGBANoValue;
-    float     active_fog_density = 0;
+    //RGBAColor active_fog_rgb     = kRGBANoValue;
+    //float     active_fog_density = 0;
 
     for (int i = 0; i < current_render_unit; i++)
         local_unit_map[i] = &local_units[i];
@@ -299,7 +299,7 @@ void RenderCurrentUnits(void)
 
         // detect changes in texture/alpha/blending state
 
-        if (unit->fog_color != kRGBANoValue)
+        /*if (unit->fog_color != kRGBANoValue)
         {
             if (unit->fog_color != active_fog_rgb)
             {
@@ -319,7 +319,7 @@ void RenderCurrentUnits(void)
                 state->Disable(GL_FOG);
         }
         else
-            state->Disable(GL_FOG);
+            state->Disable(GL_FOG);*/
 
         if (active_pass != unit->pass)
         {


### PR DESCRIPTION
As we evaluate the way forward regarding rendering, worrying about GL 1.x fog should not be part of the equation. I have disabled all functionality related to fog in the code but left it in place as some references may be useful in the future (DDF parsing, when/where to check for the presence of fog, etc). One thing I have deleted entirely is the "fogwall" concept, i.e., the automatic creation of translucent walls matching the fog color in the absence of a midtexture.