### PR TITLE
Update CI workflows; remove MinGW CI builds

### DIFF
--- a/.github/workflows/cmake-release.yml
+++ b/.github/workflows/cmake-release.yml
@@ -17,47 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure CMake MSVC
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G"Visual Studio 16 2019"
+        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
       - name: Build MSVC
         run: |
           cmake --build build --target GenerateEPKS
           cmake --build build --config ${{env.BUILD_TYPE}}
       - uses: actions/upload-artifact@v4
         with:
-          name: edge-classic-msvc
+          name: edge-classic
           path: |
             autoload
             docs
-            edge_base/*.epk
             soundfont
             edge-classic.exe
             *.epk
             CHANGELOG.md
           retention-days: ${{env.RETENTION_DAYS}} 
-  build-mingw:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download w64devkit
-        run: invoke-webrequest https://github.com/skeeto/w64devkit/releases/download/v1.23.0/w64devkit-i686-1.23.0.zip -outfile ${{github.workspace}}\w64devkit.zip
-      - name: Extract w64devkit
-        run: expand-archive -path ${{github.workspace}}\w64devkit.zip -destinationpath ${{github.workspace}}
-      - name: Set environment variables and build
-        run: |
-          $env:Path = "${{github.workspace}}\w64devkit\bin;" + $env:Path
-          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-isystem ${{github.workspace}}\w64devkit\include" -G "MinGW Makefiles"
-          cmake --build build --target GenerateEPKS
-          cmake --build build --config ${{env.BUILD_TYPE}}
-          strip ${{github.workspace}}\edge-classic.exe
-      - uses: actions/upload-artifact@v4
-        with:
-          name: edge-classic-mingw
-          path: |
-            autoload
-            docs
-            edge_base/*.epk
-            soundfont
-            edge-classic.exe
-            *.epk
-            CHANGELOG.md
-          retention-days: ${{env.RETENTION_DAYS}}     

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,36 +42,10 @@ jobs:
         name: edge-classic-linux
         path: |
           ${{github.workspace}}/autoload
-          ${{github.workspace}}/edge_base
           ${{github.workspace}}/edge_defs
           ${{github.workspace}}/soundfont
           ${{github.workspace}}/edge-classic
         retention-days: ${{env.RETENTION_DAYS}}
-
-  build-mingw:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download w64devkit
-        run: invoke-webrequest https://github.com/skeeto/w64devkit/releases/download/v1.23.0/w64devkit-i686-1.23.0.zip -outfile ${{github.workspace}}\w64devkit.zip
-      - name: Extract w64devkit
-        run: expand-archive -path ${{github.workspace}}\w64devkit.zip -destinationpath ${{github.workspace}}
-      - name: Set environment variables and build
-        run: |
-          $env:Path = "${{github.workspace}}\w64devkit\bin;" + $env:Path
-          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-isystem ${{github.workspace}}\w64devkit\include" -G "MinGW Makefiles"
-          cmake --build build --config ${{env.BUILD_TYPE}}
-          strip ${{github.workspace}}\edge-classic.exe
-      - uses: actions/upload-artifact@v4
-        with:
-          name: edge-classic-mingw
-          path: |
-            autoload
-            edge_base
-            edge_defs
-            soundfont
-            edge-classic.exe
-          retention-days: ${{env.RETENTION_DAYS}}
 
   build-msvc:
     runs-on: windows-latest
@@ -86,7 +60,6 @@ jobs:
           name: edge-classic-msvc
           path: |
             autoload
-            edge_base
             edge_defs
             soundfont
             edge-classic.exe
@@ -112,7 +85,6 @@ jobs:
         name: edge-classic-macos
         path: |
           ${{github.workspace}}/autoload
-          ${{github.workspace}}/edge_base
           ${{github.workspace}}/edge_defs
           ${{github.workspace}}/soundfont
           ${{github.workspace}}/edge-classic


### PR DESCRIPTION
This updates our CI workflows to remove references to the now-nonexistent "edge_base" folder, as well as nixes the MinGW workflow (this may return in the future when the program is in a more stable state/further along in development)