### PR TITLE
Make new XGL node file name formatting match p_setup

### DIFF
--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -429,7 +429,7 @@ void ProcessPackContents()
                 std::string udmf_string = udmf_file->ReadAsString();
                 delete udmf_file;
                 udmf_hash = epi::StringHash64(udmf_string);
-                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%u.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
+                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%lu.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
                 if (!epi::FileExists(node_file))
                     ajbsp::BuildLevel(epi::GetStem(entry.pack_path_), node_file, udmf_string);
             }


### PR DESCRIPTION
This fixes the inconsistency in name formatting with newly generated node files versus the file name that p_setup will look for when loading a level. On some platforms/OSes this was causing node file opening to fail.