### PR TITLE
Initial uncapped framerate implementation

### DIFF
--- a/source_files/edge/con_con.cc
+++ b/source_files/edge/con_con.cc
@@ -81,7 +81,6 @@ static char input_line[kMaximumConsoleInput + 2];
 static int  input_position = 0;
 
 int                    console_cursor;
-extern ConsoleVariable double_framerate;
 
 static constexpr uint8_t kConsoleKeyRepeatDelay = ((250 * kTicRate) / 1000);
 static constexpr uint8_t kConsoleKeyRepeatRate  = (kTicRate / 15);
@@ -909,7 +908,7 @@ bool ConsoleResponder(InputEvent *ev)
         case kSpace:
         case kBackspace:
         case kDelete:
-            repeat_countdown = kConsoleKeyRepeatDelay * (double_framerate.d_ ? 2 : 1);
+            repeat_countdown = kConsoleKeyRepeatDelay;
             break;
         default:
             repeat_countdown = 0;
@@ -926,11 +925,7 @@ bool ConsoleResponder(InputEvent *ev)
 
 void ConsoleTicker(void)
 {
-    int add = 1;
-    if (double_framerate.d_)
-        add = 0;
-
-    console_cursor = (console_cursor + add) & 31;
+    console_cursor = (console_cursor + 1) & 31;
 
     if (console_visible != kConsoleVisibilityNotVisible)
     {
@@ -954,7 +949,7 @@ void ConsoleTicker(void)
 
                 while (repeat_countdown <= 0)
                 {
-                    repeat_countdown += kConsoleKeyRepeatRate * (double_framerate.d_ ? 2 : 1);
+                    repeat_countdown += kConsoleKeyRepeatRate;
                     ConsoleHandleKey(repeat_key, keys_shifted, false);
                 }
             }

--- a/source_files/edge/e_input.cc
+++ b/source_files/edge/e_input.cc
@@ -44,8 +44,6 @@
 extern bool ConsoleResponder(InputEvent *ev);
 extern bool GameResponder(InputEvent *ev);
 
-extern ConsoleVariable double_framerate;
-
 //
 // EVENT HANDLING
 //
@@ -310,7 +308,7 @@ void BuildEventTicCommand(EventTicCommand *cmd)
     // Turning
     if (!strafe)
     {
-        float turn = angle_turn[t_speed] / (double_framerate.d_ ? 2 : 1) * joy_forces[kAxisTurn];
+        float turn = angle_turn[t_speed] * joy_forces[kAxisTurn];
 
         turn *= turn_speed.f_;
 
@@ -332,7 +330,7 @@ void BuildEventTicCommand(EventTicCommand *cmd)
         cmd->mouselook_turn = RoundToInteger(mlook);
     }
 
-    // Forward [ no change for 70Hz ]
+    // Forward
     {
         float forward = forward_move[speed] * joy_forces[kAxisForward];
 
@@ -346,7 +344,7 @@ void BuildEventTicCommand(EventTicCommand *cmd)
         cmd->forward_move = RoundToInteger(forward);
     }
 
-    // Sideways [ no change for 70Hz ]
+    // Sideways
     {
         float side = side_move[speed] * joy_forces[kAxisStrafe];
 

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -78,7 +78,6 @@
 #include "w_files.h"
 #include "w_sprite.h"
 
-extern ConsoleVariable double_framerate;
 extern ConsoleVariable busy_wait;
 
 extern ConsoleVariable gamma_correction;

--- a/source_files/edge/e_player.h
+++ b/source_files/edge/e_player.h
@@ -147,6 +147,9 @@ class Player
     // will be kFloatUnused until the first think.
     float view_z_;
 
+    // Uncapped test -  Dasho
+    float old_view_z_;
+
     // Base height above floor for view_z.  Tracks `std_viewheight' but
     // is different when squatting (i.e. after a fall).
     float view_height_;

--- a/source_files/edge/g_game.cc
+++ b/source_files/edge/g_game.cc
@@ -56,8 +56,6 @@
 #include "version.h"
 #include "w_files.h"
 
-extern ConsoleVariable double_framerate;
-
 GameState game_state = kGameStateNothing;
 
 GameAction game_action = kGameActionNothing;
@@ -384,26 +382,6 @@ void DoBigGameStuff(void)
 
 void GameTicker(void)
 {
-    bool extra_tic = (game_tic & 1) == 1;
-
-    if (extra_tic && double_framerate.d_)
-    {
-        switch (game_state)
-        {
-        case kGameStateLevel:
-            // get commands
-            GrabTicCommands();
-
-            //!!!  MapObjectTicker();
-            MapObjectTicker(true);
-            break;
-
-        default:
-            break;
-        }
-        return;
-    }
-
     // ANIMATE FLATS AND TEXTURES GLOBALLY
     AnimationTicker();
 
@@ -415,7 +393,7 @@ void GameTicker(void)
         // get commands
         GrabTicCommands();
 
-        MapObjectTicker(false);
+        MapObjectTicker();
         
         // do player reborns if needed
         CheckPlayersReborn();

--- a/source_files/edge/i_ctrl.cc
+++ b/source_files/edge/i_ctrl.cc
@@ -37,8 +37,6 @@
 #include "r_modes.h"
 #include "sokol_time.h"
 
-extern ConsoleVariable double_framerate;
-
 static void GamepadDebugCallback(ConsoleVariable *self)
 {
     Gamepad_setDebug((gamepad_bool)self->d_);
@@ -696,7 +694,7 @@ int GetTime(void)
 {
     uint32_t t = (uint32_t)stm_ms(stm_now());
 
-    int factor = (double_framerate.d_ ? 70 : 35);
+    int factor = 35;
 
     // more complex than "t*70/1000" to give more accuracy
     return (t / 1000) * factor + (t % 1000) * factor / 1000;

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -25,6 +25,7 @@
 #include "i_system.h"
 #include "m_argv.h"
 #include "m_misc.h"
+#include "n_network.h"
 #include "r_modes.h"
 #include "version.h"
 
@@ -344,6 +345,9 @@ void FinishFrame(void)
     EDGE_TracyPlot("draw_sector_glow_iterator", (int64_t)ec_frame_stats.draw_sector_glow_iterator);
 
     EDGE_FrameMark;
+
+    if (uncapped_frames.d_)
+        fractional_tic = (float)(GetMilliseconds() * 35 % 1000) / 1000;
 
     if (vsync.CheckModified())
     {

--- a/source_files/edge/n_network.h
+++ b/source_files/edge/n_network.h
@@ -18,8 +18,12 @@
 
 #pragma once
 
+#include "con_var.h"
+
 extern bool network_game;
 extern int  game_tic;
+extern float fractional_tic;
+extern ConsoleVariable uncapped_frames;
 
 void NetworkInitialize(void);
 void NetworkShutdown(void);

--- a/source_files/edge/p_forces.cc
+++ b/source_files/edge/p_forces.cc
@@ -45,8 +45,6 @@
 
 constexpr float kPushFactor = 64.0f;
 
-extern ConsoleVariable double_framerate;
-
 std::vector<Force *> active_forces;
 
 static Force *current_force; // for PushThingCallback
@@ -205,12 +203,8 @@ void AddSectorForce(Sector *sec, bool is_wind, float x_mag, float y_mag)
 //
 // Executes all force effects for the current tic.
 //
-void RunForces(bool extra_tic)
+void RunForces()
 {
-    // TODO: review what needs updating here for 70 Hz
-    if (extra_tic && double_framerate.d_)
-        return;
-
     std::vector<Force *>::iterator FI;
 
     for (FI = active_forces.begin(); FI != active_forces.end(); FI++)

--- a/source_files/edge/p_local.h
+++ b/source_files/edge/p_local.h
@@ -92,7 +92,7 @@ void CreatePlayer(int pnum, bool is_bot);
 void DestroyAllPlayers(void);
 void GiveInitialBenefits(Player *player, const MapObjectDefinition *info);
 
-bool PlayerThink(Player *player, bool extra_tic);
+bool PlayerThink(Player *player);
 void UpdateAvailWeapons(Player *p);
 void UpdateTotalArmour(Player *p);
 
@@ -116,7 +116,7 @@ int  MapObjectFindLabel(MapObject *mobj, const char *label);
 bool MapObjectSetState(MapObject *mobj, int state);
 bool MapObjectSetStateDeferred(MapObject *mobj, int state, int tic_skip);
 void MapObjectSetDirectionAndSpeed(MapObject *mobj, BAMAngle angle, float slope, float speed);
-void RunMapObjectThinkers(bool extra_tic);
+void RunMapObjectThinkers();
 void SpawnDebris(float x, float y, float z, BAMAngle angle, const MapObjectDefinition *debris);
 void SpawnPuff(float x, float y, float z, const MapObjectDefinition *puff, BAMAngle angle);
 void SpawnBlood(float x, float y, float z, float damage, BAMAngle angle, const MapObjectDefinition *blood);

--- a/source_files/edge/p_map.cc
+++ b/source_files/edge/p_map.cc
@@ -241,6 +241,8 @@ bool TeleportMove(MapObject *thing, float x, float y, float z)
     thing->floor_z_   = move_check.floor_z;
     thing->ceiling_z_ = move_check.ceiling_z;
 
+    thing->interpolate_ = false;
+
     ChangeThingPosition(thing, x, y, z);
 
     return true;

--- a/source_files/edge/p_mobj.h
+++ b/source_files/edge/p_mobj.h
@@ -207,6 +207,12 @@ class MapObject : public Position
     // properties from vertical region the thing is in
     struct RegionProperties *region_properties_ = nullptr;
 
+    // Uncapped stuff - Dasho
+    float old_x_        = 0;
+    float old_y_        = 0;
+    BAMAngle old_angle_ = 0;
+    BAMAngle old_vertical_angle_ = 0;
+
     // Vert slope stuff maybe
     float old_z_       = 0;
     float old_floor_z_ = 0;
@@ -329,12 +335,6 @@ class MapObject : public Position
     // hash values for TUNNEL missiles
     uint32_t tunnel_hash_[2] = {0, 0};
 
-    // position interpolation (disabled when lerp_num <= 1)
-    short interpolation_number_   = 0;
-    short interpolation_position_ = 0;
-
-    vec3s interpolation_from_ = {{0, 0, 0}};
-
     // touch list: sectors this thing is in or touches
     struct TouchNode *touch_sectors_ = nullptr;
 
@@ -361,6 +361,9 @@ class MapObject : public Position
     bool slope_sight_hit_ = false;
 
     int teleport_tic_ = 0;
+
+    // Uncapped test - Dasho
+    bool interpolate_ = false;
 
   public:
     bool IsRemoved() const;

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -316,6 +316,12 @@ static MapObject *SpawnMapThing(const MapObjectDefinition *info, float x, float 
     if (tag > 0)
         mo->tag_ = tag;
 
+    mo->interpolate_ = false;
+    mo->old_x_ = mo->x;
+    mo->old_y_ = mo->y;
+    mo->old_z_ = mo->z;
+    mo->old_angle_ = mo->angle_;
+
     return mo;
 }
 
@@ -1177,6 +1183,12 @@ static void LoadUDMFSectors()
             }
 
             ss->sound_player = -1;
+
+            ss->old_floor_height = ss->floor_height;
+            ss->interpolated_floor_height = ss->floor_height;
+            ss->old_ceiling_height = ss->ceiling_height;
+            ss->interpolated_ceiling_height = ss->ceiling_height;
+            ss->old_game_tic = -1;
 
             // -AJA- 1999/07/29: Keep sectors with same tag in a list.
             GroupSectorTags(ss, level_sectors, cur_sector);

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -49,8 +49,6 @@
 #include "s_music.h"
 #include "s_sound.h"
 
-extern ConsoleVariable double_framerate;
-
 // Level exit timer
 bool level_timer;
 int  level_time_count;
@@ -1410,8 +1408,6 @@ static inline void PlayerInProperties(Player *player, float bz, float tz, float 
     const SectorType *special = props->special;
     float             damage, factor;
 
-    bool extra_tic = ((game_tic & 1) == 1);
-
     if (!special || ceiling_height < floor_height)
         return;
 
@@ -1427,7 +1423,7 @@ static inline void PlayerInProperties(Player *player, float bz, float tz, float 
         player->powers_[kPowerTypeScuba] <= 0)
     {
         int subtract = 1;
-        if ((double_framerate.d_ && extra_tic) || !should_choke)
+        if (!should_choke)
             subtract = 0;
         player->air_in_lungs_ -= subtract;
         player->underwater_ = true;
@@ -1508,9 +1504,6 @@ static inline void PlayerInProperties(Player *player, float bz, float tz, float 
             factor = 0;
     }
     else if (player->powers_[kPowerTypeAcidSuit] && !special->damage_.bypass_all_)
-        factor = 0;
-
-    if (double_framerate.d_ && extra_tic)
         factor = 0;
 
     if (factor > 0 && (level_time_elapsed % (1 + special->damage_.delay_)) == 0)
@@ -1636,15 +1629,15 @@ void PlayerInSpecialSector(Player *player, Sector *sec, bool should_choke)
 //
 // Animate planes, scroll walls, etc.
 //
-void UpdateSpecials(bool extra_tic)
+void UpdateSpecials()
 {
     // For anim stuff
-    float factor = double_framerate.d_ ? 0.5f : 1.0f;
+    float factor = 1.0f;
 
     // LEVEL TIMER
     if (level_timer == true)
     {
-        level_time_count -= (double_framerate.d_ && extra_tic) ? 0 : 1;
+        level_time_count--;
 
         if (!level_time_count)
             ExitLevel(1);
@@ -1735,11 +1728,6 @@ void UpdateSpecials(bool extra_tic)
                                                                                        : sec_ref->original_height;
                 float sy        = tdy * ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
                 float sx        = tdx * ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
-                if (double_framerate.d_ && special_ref->scroll_type_ & BoomScrollerTypeDisplace)
-                {
-                    sy *= 2;
-                    sx *= 2;
-                }
                 if (ld->side[0])
                 {
                     if (ld->side[0]->top.image)
@@ -1785,11 +1773,6 @@ void UpdateSpecials(bool extra_tic)
                                                                                        : sec_ref->original_height;
                 float sy        = x_speed * ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
                 float sx        = y_speed * ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
-                if (double_framerate.d_ && special_ref->scroll_type_ & BoomScrollerTypeDisplace)
-                {
-                    sy *= 2;
-                    sx *= 2;
-                }
                 if (ld->side[0])
                 {
                     if (ld->side[0]->top.image)
@@ -2013,11 +1996,6 @@ void UpdateSpecials(bool extra_tic)
                        ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
             float sx = line_ref->length / 32.0f * line_ref->delta_x / line_ref->length *
                        ((sec_ref->floor_height + sec_ref->ceiling_height) - heightref);
-            if (double_framerate.d_ && special_ref->scroll_type_ & BoomScrollerTypeDisplace)
-            {
-                sy *= 2;
-                sx *= 2;
-            }
             if (special_ref->sector_effect_ & kSectorEffectTypePushThings)
             {
                 sec->properties.net_push.y += kBoomCarryFactor * sy;
@@ -2086,8 +2064,7 @@ void UpdateSpecials(bool extra_tic)
     }
 
     // DO BUTTONS
-    if (!double_framerate.d_ || !extra_tic)
-        UpdateButtons();
+    UpdateButtons();
 }
 
 //
@@ -2221,7 +2198,7 @@ void SpawnMapSpecials2(int autotag)
 
             sector->properties.push.x += epi::BAMCos(secSpecial->push_angle_) * mul;
             sector->properties.push.y += epi::BAMSin(secSpecial->push_angle_) * mul;
-            sector->properties.push.z += secSpecial->push_zspeed_ / (double_framerate.d_ ? 89.2f : 100.0f);
+            sector->properties.push.z += secSpecial->push_zspeed_ / 100.0f;
         }
 
         // Scrollers

--- a/source_files/edge/p_spec.h
+++ b/source_files/edge/p_spec.h
@@ -159,7 +159,7 @@ void SpawnMapSpecials1(void);
 void SpawnMapSpecials2(int autotag);
 
 // every tic
-void UpdateSpecials(bool extra_tic);
+void UpdateSpecials();
 
 // when needed
 bool UseSpecialLine(MapObject *thing, Line *line, int side, float open_bottom, float open_top);
@@ -207,7 +207,7 @@ bool RunPlaneMover(Sector *sec, const PlaneMoverDefinition *type, Sector *model)
 bool RunSlidingDoor(Line *door, Line *act_line, MapObject *thing, const LineType *special);
 bool SectorIsLowering(Sector *sec);
 
-void RunForces(bool extra_tic);
+void RunForces();
 void DestroyAllForces(void);
 void AddPointForce(Sector *sec, float length);
 void AddSectorForce(Sector *sec, bool is_wind, float x_mag, float y_mag);

--- a/source_files/edge/p_tick.cc
+++ b/source_files/edge/p_tick.cc
@@ -45,12 +45,11 @@ bool fast_forward_active;
 bool erraticism_active = false;
 
 extern ConsoleVariable erraticism;
-extern ConsoleVariable double_framerate;
 
 //
 // MapObjectTicker
 //
-void MapObjectTicker(bool extra_tic)
+void MapObjectTicker()
 {
     if (paused)
         return;
@@ -59,7 +58,7 @@ void MapObjectTicker(bool extra_tic)
 
     if (erraticism.d_)
     {
-        bool keep_thinking = PlayerThink(players[console_player], extra_tic);
+        bool keep_thinking = PlayerThink(players[console_player]);
 
         if (!keep_thinking)
         {
@@ -70,32 +69,27 @@ void MapObjectTicker(bool extra_tic)
         for (int pnum = 0; pnum < kMaximumPlayers; pnum++)
         {
             if (players[pnum] && players[pnum] != players[console_player])
-                PlayerThink(players[pnum], extra_tic);
+                PlayerThink(players[pnum]);
         }
     }
     else
     {
         for (int pnum = 0; pnum < kMaximumPlayers; pnum++)
             if (players[pnum])
-                PlayerThink(players[pnum], extra_tic);
+                PlayerThink(players[pnum]);
     }
 
-    RunForces(extra_tic);
-    RunMapObjectThinkers(extra_tic);
+    RunForces();
+    RunMapObjectThinkers();
 
-    if (!extra_tic || !double_framerate.d_)
-        RunLights();
+    RunLights();
 
     RunActivePlanes();
     RunActiveSliders();
 
-    if (!extra_tic || !double_framerate.d_)
-        RunAmbientSounds();
+    RunAmbientSounds();
 
-    UpdateSpecials(extra_tic);
-
-    if (extra_tic && double_framerate.d_)
-        return;
+    UpdateSpecials();
 
     ItemRespawn();
 
@@ -120,7 +114,7 @@ void HubFastForward(void)
     }
 
     for (int k = 0; k < kTicRate / 3; k++)
-        MapObjectTicker(false);
+        MapObjectTicker();
 
     fast_forward_active = false;
 }

--- a/source_files/edge/p_tick.h
+++ b/source_files/edge/p_tick.h
@@ -28,7 +28,7 @@
 // Called by C_Ticker,
 // can call G_PlayerExited.
 // Carries out all thinking of monsters and players.
-void MapObjectTicker(bool extra_tic);
+void MapObjectTicker();
 
 void HubFastForward(void);
 

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -41,8 +41,6 @@
 #include "s_blit.h"
 #include "s_sound.h"
 
-extern ConsoleVariable double_framerate;
-
 EDGE_DEFINE_CONSOLE_VARIABLE(erraticism, "0", kConsoleVariableFlagArchive)
 
 EDGE_DEFINE_CONSOLE_VARIABLE(view_bobbing, "0", kConsoleVariableFlagArchive)
@@ -62,7 +60,7 @@ static SoundEffect *sfx_jpflow;
 
 static void UpdatePowerups(Player *player);
 
-static void CalcHeight(Player *player, bool extra_tic)
+static void CalcHeight(Player *player)
 {
     bool    onground  = player->map_object_->z <= player->map_object_->floor_z_;
     float   sink_mult = 1.0f;
@@ -117,7 +115,7 @@ static void CalcHeight(Player *player, bool extra_tic)
     // ----CALCULATE VIEWHEIGHT----
     if (player->player_state_ == kPlayerAlive)
     {
-        player->view_height_ += player->delta_view_height_ * (double_framerate.d_ ? 0.5 : 1);
+        player->view_height_ += player->delta_view_height_;
 
         if (player->view_height_ > player->standard_view_height_)
         {
@@ -148,8 +146,7 @@ static void CalcHeight(Player *player, bool extra_tic)
         {
             // use a weird number to minimise chance of hitting
             // zero when delta_view_height_ goes neg -> positive.
-            if (!extra_tic || !double_framerate.d_)
-                player->delta_view_height_ += 0.24162f;
+            player->delta_view_height_ += 0.24162f;
         }
     }
 
@@ -178,9 +175,6 @@ static void CalcHeight(Player *player, bool extra_tic)
         else
             bob_z *= (6 - player->jump_wait_) / 6.0;
     }
-
-    if (double_framerate.d_)
-        bob_z *= 0.5;
 
     if (view_bobbing.d_ > 1)
         bob_z = 0;
@@ -214,7 +208,7 @@ void PlayerJump(Player *pl, float dz, int wait)
     }
 }
 
-static void MovePlayer(Player *player, bool extra_tic)
+static void MovePlayer(Player *player)
 {
     EventTicCommand *cmd;
     MapObject       *mo = player->map_object_;
@@ -269,8 +263,8 @@ static void MovePlayer(Player *player, bool extra_tic)
     // compute XY and Z speeds, taking swimming (etc) into account
     // (we try to swim in view direction -- assumes no gravity).
 
-    base_xy_speed = player->map_object_->speed_ / (double_framerate.d_ ? 64.0f : 32.0f);
-    base_z_speed  = player->map_object_->speed_ / (double_framerate.d_ ? 57.0f : 64.0f);
+    base_xy_speed = player->map_object_->speed_ / 32.0f;
+    base_z_speed  = player->map_object_->speed_ / 64.0f;
 
     // Do not let the player control movement if not onground.
     // -MH- 1998/06/18  unless he has the JetPack!
@@ -367,15 +361,12 @@ static void MovePlayer(Player *player, bool extra_tic)
     // -ACB- 1998/08/09 Check that jumping is allowed in the current_map
     //                  Make player pause before jumping again
 
-    if (!extra_tic || !double_framerate.d_)
+    if (mo->info_->jumpheight_ > 0 && (cmd->upward_move > 4))
     {
-        if (mo->info_->jumpheight_ > 0 && (cmd->upward_move > 4))
+        if (!jumping && !crouching && !swimming && !flying && onground && !onladder)
         {
-            if (!jumping && !crouching && !swimming && !flying && onground && !onladder)
-            {
-                PlayerJump(player, player->map_object_->info_->jumpheight_ / (double_framerate.d_ ? 1.25f : 1.4f),
-                           player->map_object_->info_->jump_delay_);
-            }
+            PlayerJump(player, player->map_object_->info_->jumpheight_ / 1.4f,
+                        player->map_object_->info_->jump_delay_);
         }
     }
 
@@ -387,7 +378,7 @@ static void MovePlayer(Player *player, bool extra_tic)
     {
         if (mo->height_ > mo->info_->crouchheight_)
         {
-            mo->height_ = GLM_MAX(mo->height_ - 2.0f / (double_framerate.d_ ? 2.0 : 1.0), mo->info_->crouchheight_);
+            mo->height_ = GLM_MAX(mo->height_ - 2.0f, mo->info_->crouchheight_);
             mo->player_->delta_view_height_ = -1.0f;
         }
     }
@@ -395,7 +386,7 @@ static void MovePlayer(Player *player, bool extra_tic)
     {
         if (mo->height_ < mo->info_->height_)
         {
-            float new_height = GLM_MIN(mo->height_ + 2 / (double_framerate.d_ ? 2 : 1), mo->info_->height_);
+            float new_height = GLM_MIN(mo->height_ + 2, mo->info_->height_);
 
             // prevent standing up inside a solid area
             if ((mo->flags_ & kMapObjectFlagNoClip) || mo->z + new_height <= mo->ceiling_z_)
@@ -425,15 +416,9 @@ static void MovePlayer(Player *player, bool extra_tic)
     }
 }
 
-static void DeathThink(Player *player, bool extra_tic)
+static void DeathThink(Player *player)
 {
-    int subtract = extra_tic ? 0 : 1;
-
-    if (!double_framerate.d_)
-        subtract = 1;
-
     // fall on your face when dying.
-
     float dx, dy, dz;
 
     BAMAngle angle;
@@ -443,19 +428,18 @@ static void DeathThink(Player *player, bool extra_tic)
     // -AJA- 1999/12/07: don't die mid-air.
     player->powers_[kPowerTypeJetpack] = 0;
 
-    if (!extra_tic)
-        MovePlayerSprites(player);
+    MovePlayerSprites(player);
 
     // fall to the ground
     if (player->view_height_ > player->standard_view_height_)
-        player->view_height_ -= 1.0f / (double_framerate.d_ ? 2.0 : 1.0);
+        player->view_height_ -= 1.0f;
     else if (player->view_height_ < player->standard_view_height_)
         player->view_height_ = player->standard_view_height_;
 
     player->delta_view_height_ = 0.0f;
     player->kick_offset_       = 0.0f;
 
-    CalcHeight(player, extra_tic);
+    CalcHeight(player);
 
     if (player->attacker_ && player->attacker_ != player->map_object_)
     {
@@ -478,11 +462,11 @@ static void DeathThink(Player *player, bool extra_tic)
             player->map_object_->vertical_angle_ = epi::BAMFromATan(slope);
 
             if (player->damage_count_ > 0)
-                player->damage_count_ -= subtract;
+                player->damage_count_--;
         }
         else
         {
-            unsigned int factor = double_framerate.d_ ? 2 : 1;
+            unsigned int factor = 1;
             if (delta < kBAMAngle180)
                 delta /= (5 * factor);
             else
@@ -504,7 +488,7 @@ static void DeathThink(Player *player, bool extra_tic)
             player->map_object_->vertical_angle_ += delta_s;
 
             if (player->damage_count_ && (level_time_elapsed % 3) == 0)
-                player->damage_count_ -= subtract;
+                player->damage_count_--;
         }
     }
     else if (player->damage_count_ > 0)
@@ -512,7 +496,7 @@ static void DeathThink(Player *player, bool extra_tic)
 
     // -AJA- 1999/08/07: Fade out armor points too.
     if (player->bonus_count_)
-        player->bonus_count_ -= subtract;
+        player->bonus_count_--;
 
     UpdatePowerups(player);
 
@@ -653,11 +637,20 @@ void P_DumpMobjsTemp(void)
     LogWarning("END OF MOBJs\n");
 }
 
-bool PlayerThink(Player *player, bool extra_tic)
+bool PlayerThink(Player *player)
 {
     EventTicCommand *cmd = &player->command_;
 
     EPI_ASSERT(player->map_object_);
+
+    player->map_object_->interpolate_ = true;
+    player->map_object_->old_x_ = player->map_object_->x;
+    player->map_object_->old_y_ = player->map_object_->y;
+    player->map_object_->old_z_ = player->map_object_->z;
+    player->map_object_->old_angle_ = player->map_object_->angle_;
+    player->map_object_->old_vertical_angle_ = player->map_object_->vertical_angle_;
+
+    player->old_view_z_ = player->view_z_;
 
     bool should_think = true;
 
@@ -677,20 +670,17 @@ bool PlayerThink(Player *player, bool extra_tic)
         player->map_object_->flags_ &= ~kMapObjectFlagNoClip;
 
     // chain saw run forward
-    if (extra_tic || !double_framerate.d_)
+    if (player->map_object_->flags_ & kMapObjectFlagJustAttacked)
     {
-        if (player->map_object_->flags_ & kMapObjectFlagJustAttacked)
-        {
-            cmd->angle_turn   = 0;
-            cmd->forward_move = 64;
-            cmd->side_move    = 0;
-            player->map_object_->flags_ &= ~kMapObjectFlagJustAttacked;
-        }
+        cmd->angle_turn   = 0;
+        cmd->forward_move = 64;
+        cmd->side_move    = 0;
+        player->map_object_->flags_ &= ~kMapObjectFlagJustAttacked;
     }
 
     if (player->player_state_ == kPlayerDead)
     {
-        DeathThink(player, extra_tic);
+        DeathThink(player);
         if (player->map_object_->region_properties_->special &&
             player->map_object_->region_properties_->special->e_exit_ != kExitTypeNone)
         {
@@ -706,20 +696,16 @@ bool PlayerThink(Player *player, bool extra_tic)
         return true;
     }
 
-    int subtract = extra_tic ? 0 : 1;
-    if (!double_framerate.d_)
-        subtract = 1;
-
     // Move/Look around.  Reactiontime is used to prevent movement for a
     // bit after a teleport.
 
     if (player->map_object_->reaction_time_)
-        player->map_object_->reaction_time_ -= subtract;
+        player->map_object_->reaction_time_--;
 
     if (player->map_object_->reaction_time_ == 0)
-        MovePlayer(player, extra_tic);
+        MovePlayer(player);
 
-    CalcHeight(player, extra_tic);
+    CalcHeight(player);
 
     if (erraticism.d_)
     {
@@ -791,10 +777,6 @@ bool PlayerThink(Player *player, bool extra_tic)
 
     player->action_button_down_[0] = (cmd->extended_buttons & kExtendedButtonCodeAction1) ? true : false;
     player->action_button_down_[1] = (cmd->extended_buttons & kExtendedButtonCodeAction2) ? true : false;
-
-    // FIXME separate code more cleanly
-    if (extra_tic && double_framerate.d_)
-        return should_think;
 
     // decrement jump_wait_ counter
     if (player->jump_wait_ > 0)

--- a/source_files/edge/r_defs.h
+++ b/source_files/edge/r_defs.h
@@ -170,6 +170,11 @@ struct Sector
 {
     float floor_height, ceiling_height;
 
+    // Uncapped test - Dasho
+    float old_floor_height, old_ceiling_height;
+    float interpolated_floor_height, interpolated_ceiling_height;
+    int old_game_tic;
+
     MapSurface floor, ceiling;
 
     RegionProperties properties;

--- a/source_files/edge/r_image.cc
+++ b/source_files/edge/r_image.cc
@@ -68,8 +68,6 @@ extern ImageData *ReadAsEpiBlock(Image *rim);
 
 extern epi::File *OpenUserFileOrLump(ImageDefinition *def);
 
-extern ConsoleVariable double_framerate;
-
 extern void DeleteSkyTextures(void);
 extern void DeleteColourmapTextures(void);
 

--- a/source_files/epi/epi_bam.h
+++ b/source_files/epi/epi_bam.h
@@ -97,6 +97,26 @@ inline float BAMTan(BAMAngle bam)
     return tanf(RadiansFromBAM(bam));
 }
 
+inline BAMAngle BAMInterpolate(BAMAngle old_angle, BAMAngle new_angle, float along)
+{
+    if (new_angle == old_angle)
+        return new_angle;
+    else if (new_angle > old_angle)
+    {
+        if (new_angle - old_angle < kBAMAngle270)
+            return old_angle + (BAMAngle)(along * (new_angle - old_angle));
+        else
+            return old_angle - (BAMAngle)(along * (old_angle - new_angle));
+    }
+    else
+    {
+        if (old_angle - new_angle < kBAMAngle270)
+            return old_angle - (BAMAngle)(along * (old_angle - new_angle));
+        else
+            return old_angle + (BAMAngle)(along * (new_angle - old_angle));
+    }
+}
+
 } // namespace epi
 
 //--- editor settings ---


### PR DESCRIPTION
This hardlocks the playsim to 35 ticks per second and removes the behavior associated with doubling the framerate, as well as provides uncapped/interpolated rendering. Player view, map objects, and plane movers seem to work fine during regular play and time stop/erraticism. Since some elements of the program have not been reimplemented yet (automap, console, menu interface), more work may need to be done in the future.