### PR TITLE
Various accumulated fixes

### DIFF
--- a/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
+++ b/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
@@ -167,6 +167,8 @@ static void CheckDeviceNotification(DeviceNotificationData *data)
 
 #define INPUT_QUEUE_SIZE 32
 #define XINPUT_GAMEPAD_GUIDE 0x400
+
+#ifndef __WINE_XINPUT_H
 typedef struct {
 	XINPUT_CAPABILITIES Capabilities;
 	WORD VendorId;
@@ -175,6 +177,7 @@ typedef struct {
 	WORD unk1;
 	DWORD unk2;
 } XINPUT_CAPABILITIES_EX;
+#endif
 
 struct Gamepad_devicePrivate {
 	gamepad_bool isXInput;
@@ -483,7 +486,7 @@ static BOOL CALLBACK enumHatsCallback(LPCDIDEVICEOBJECTINSTANCE instance, LPVOID
 	return DIENUM_CONTINUE;
 }
 
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined __WINE_XINPUT_H
 #ifndef DIDFT_OPTIONAL
 #define DIDFT_OPTIONAL      0x80000000
 #endif

--- a/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
+++ b/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
@@ -42,8 +42,8 @@
 #include <windows.h>
 #include <regstr.h>
 #include <dinput.h>
-#include <XInput.h>
-#include <Dbt.h>
+#include <xinput.h>
+#include <dbt.h>
 
 // The following code is from SDL2
 // detects gamepad device remove/attach events without having to poll multiple times per second
@@ -168,7 +168,6 @@ static void CheckDeviceNotification(DeviceNotificationData *data)
 #define INPUT_QUEUE_SIZE 32
 #define XINPUT_GAMEPAD_GUIDE 0x400
 
-#ifndef __WINE_XINPUT_H
 typedef struct {
 	XINPUT_CAPABILITIES Capabilities;
 	WORD VendorId;
@@ -176,8 +175,7 @@ typedef struct {
 	WORD VersionNumber;
 	WORD unk1;
 	DWORD unk2;
-} XINPUT_CAPABILITIES_EX;
-#endif
+} LIBSTEM_XINPUT_CAPABILITIES_EX;
 
 struct Gamepad_devicePrivate {
 	gamepad_bool isXInput;
@@ -208,7 +206,7 @@ static const char * xInputDeviceNames[4] = {
 };
 
 static DWORD (WINAPI * XInputGetState_proc)(DWORD dwUserIndex, XINPUT_STATE * pState) = NULL;
-static DWORD (WINAPI * XInputGetCapabilitiesEx_proc)(DWORD unk1, DWORD dwUserIndex, DWORD dwFlags, XINPUT_CAPABILITIES_EX * pCapabilities) = NULL;
+static DWORD (WINAPI * XInputGetCapabilitiesEx_proc)(DWORD unk1, DWORD dwUserIndex, DWORD dwFlags, LIBSTEM_XINPUT_CAPABILITIES_EX * pCapabilities) = NULL;
 
 static LPDIRECTINPUT directInputInterface;
 static gamepad_bool inited = gamepad_false;
@@ -227,7 +225,7 @@ void Gamepad_init() {
 		} else {
 			xInputAvailable = gamepad_true;
 			XInputGetState_proc = (DWORD (WINAPI *)(DWORD, XINPUT_STATE *)) GetProcAddress(module, "XInputGetState");
-			XInputGetCapabilitiesEx_proc = (DWORD (WINAPI *)(DWORD, DWORD, DWORD, XINPUT_CAPABILITIES_EX *)) GetProcAddress(module, (LPCSTR) 108);
+			XInputGetCapabilitiesEx_proc = (DWORD (WINAPI *)(DWORD, DWORD, DWORD, LIBSTEM_XINPUT_CAPABILITIES_EX *)) GetProcAddress(module, (LPCSTR) 108);
 		}
 		
 		module = LoadLibrary("DINPUT8.dll");
@@ -842,7 +840,7 @@ static void removeDevice(unsigned int deviceIndex) {
 void Gamepad_detectDevices() {
 	HRESULT result;
 	DWORD xResult;
-	XINPUT_CAPABILITIES_EX capabilities_ex;
+	LIBSTEM_XINPUT_CAPABILITIES_EX capabilities_ex;
 	unsigned int playerIndex, deviceIndex;
 	
 	if (!inited) {

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -18,6 +18,13 @@
 
 #include "i_video.h"
 
+// Set hints to select dedicated GPU in laptop iGPU/dGPU setups
+#ifdef _WIN32
+#include "epi_windows.h"
+extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+extern "C" __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+#endif
+
 #include "edge_profiling.h"
 #include "epi_str_compare.h"
 #include "epi_str_util.h"

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -57,7 +57,7 @@
 #include "r_state.h"
 #include "s_sound.h"
 
-
+extern bool P_IsThingOnLiquidFloor(MapObject *thing);
 extern FlatDefinition *P_GetThingFlatDef(MapObject *thing);
 
 static int AttackSfxCat(const MapObject *mo)
@@ -3390,9 +3390,7 @@ void A_JumpLiquid(MapObject *mo)
     //
     // Note: nothing to do with monsters physically jumping.
 
-    FlatDefinition *flat = P_GetThingFlatDef(mo);
-
-    if (!flat || !flat->impactobject_) // Are we touching a liquid floor?
+    if (!P_IsThingOnLiquidFloor(mo)) // Are we touching a liquid floor?
     {
         return;
     }

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -1434,6 +1434,10 @@ static void P_MobjThinker(MapObject *mobj)
         if (!level_flags.enemies_respawn)
             return;
 
+        // check for NO_RESPAWN flag
+        if (mobj->extended_flags_ & kExtendedFlagNoRespawn)
+            return;
+
         mobj->move_count_++;
 
         //
@@ -1896,6 +1900,28 @@ void SpawnBlood(float x, float y, float z, float damage, BAMAngle angle, const M
 FlatDefinition *P_GetThingFlatDef(MapObject *thing)
 {
     return flatdefs.Find(thing->subsector_->sector->floor.image->name_.c_str());
+}
+
+//---------------------------------------------------------------------------
+//
+// FUNC P_IsThingOnLiquidFloor
+//
+//---------------------------------------------------------------------------
+
+// For now, this will mean any floor with an "impact object" that exists when something
+// hits it; this is usually a splash but can be any debris
+
+bool P_IsThingOnLiquidFloor(MapObject *thing)
+{
+    if (thing->flags_ & kMapObjectFlagFloat)
+        return false;
+ 
+    if (thing->z > thing->floor_z_) //are we actually touching the floor
+        return false;
+
+    FlatDefinition *liquid_check = P_GetThingFlatDef(thing);
+
+    return (liquid_check && liquid_check->impactobject_);
 }
 
 //---------------------------------------------------------------------------

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -2499,7 +2499,7 @@ void LevelSetup(void)
 
     // This needs to be cached somewhere, but it will work here while developing - Dasho
     uint64_t udmf_hash = epi::StringHash64(udmf_string);
-    node_file = epi::PathAppend("cache", epi::StringFormat("%s-%lu.xgl", current_map->name_.c_str(), udmf_hash));
+    node_file = epi::PathAppend("cache", epi::StringFormat("%s-%llu.xgl", current_map->name_.c_str(), udmf_hash));
 
     // get lump for XGL3 nodes from an XWA file
     // shouldn't happen (as during startup we checked for or built these)

--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -49,7 +49,7 @@ float room_area;
 
 static constexpr float    kMaximumBob       = 16.0f;
 static constexpr uint8_t  kZoomAngleDivisor = 4;
-static constexpr BAMAngle kMouseLookLimit   = 0x53333355; // 75 degrees
+static constexpr BAMAngle kMouseLookLimit   = BAMAngle(75.0 * 11930464.7084);
 static constexpr float    kCrouchSlowdown   = 0.5f;
 
 static SoundEffect *sfx_jpidle;
@@ -122,8 +122,7 @@ static void CalcHeight(Player *player)
             player->view_height_       = player->standard_view_height_;
             player->delta_view_height_ = 0;
         }
-        else if (sink_mult < 1.0f && !(player->map_object_->extended_flags_ & kExtendedFlagCrouching) &&
-                 player->view_height_ < player->standard_view_height_ * sink_mult)
+        else if (sink_mult < 1.0f && player->view_height_ < player->standard_view_height_ * sink_mult)
         {
             player->view_height_ = player->standard_view_height_ * sink_mult;
             if (player->delta_view_height_ <= 0)

--- a/source_files/edge/p_weapon.cc
+++ b/source_files/edge/p_weapon.cc
@@ -803,6 +803,7 @@ void SetupPlayerSprites(Player *p)
         psp->state      = nullptr;
         psp->next_state = nullptr;
         psp->screen_x = psp->screen_y = 0;
+        psp->old_screen_x = psp->old_screen_y = 0;
         psp->visibility = psp->target_visibility = 1.0f;
     }
 
@@ -826,6 +827,9 @@ void MovePlayerSprites(Player *p)
     }
 
     PlayerSprite *psp = &p->player_sprites_[0];
+
+    p->player_sprites_[kPlayerSpriteFlash].old_screen_x = p->player_sprites_[kPlayerSpriteWeapon].old_screen_x = p->player_sprites_[kPlayerSpriteWeapon].screen_x;
+    p->player_sprites_[kPlayerSpriteFlash].old_screen_y = p->player_sprites_[kPlayerSpriteWeapon].old_screen_y = p->player_sprites_[kPlayerSpriteWeapon].screen_y;
 
     for (int i = 0; i < kTotalPlayerSpriteTypes; i++, psp++)
     {

--- a/source_files/edge/p_weapon.h
+++ b/source_files/edge/p_weapon.h
@@ -58,6 +58,7 @@ struct PlayerSprite
 
     // screen position values (0 is normal)
     float screen_x, screen_y;
+    float old_screen_x, old_screen_y;  
 
     // translucency values
     float visibility;

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -188,10 +188,23 @@ static void RenderPSprite(PlayerSprite *psp, int which, Player *player, RegionPr
     float coord_W = 320.0f * widescreen_view_width_multiplier;
     float coord_H = 200.0f;
 
-    float tx1 = (coord_W - w) / 2.0 + psp->screen_x - image->ScaledOffsetX();
+    float psp_x, psp_y;
+
+    if (uncapped_frames.d_ && !paused)
+    {
+        psp_x = glm_lerp(psp->old_screen_x, psp->screen_x, fractional_tic);
+        psp_y = glm_lerp(psp->old_screen_y, psp->screen_y, fractional_tic);
+    }
+    else
+    {
+        psp_x = psp->screen_x;
+        psp_y = psp->screen_y;
+    }
+
+    float tx1 = (coord_W - w) / 2.0 + psp_x - image->ScaledOffsetX();
     float tx2 = tx1 + w;
 
-    float ty1 = -psp->screen_y + image->ScaledOffsetY() - ((h - image->ScaledHeightActual()) * 0.5f);
+    float ty1 = -psp_y + image->ScaledOffsetY() - ((h - image->ScaledHeightActual()) * 0.5f);
 
     float ty2 = ty1 + h;
 

--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -429,7 +429,7 @@ void ProcessPackContents()
                 std::string udmf_string = udmf_file->ReadAsString();
                 delete udmf_file;
                 udmf_hash = epi::StringHash64(udmf_string);
-                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%lu.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
+                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%llu.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
                 if (!epi::FileExists(node_file))
                     ajbsp::BuildLevel(epi::GetStem(entry.pack_path_), node_file, udmf_string);
             }

--- a/source_files/epi/epi_filesystem.cc
+++ b/source_files/epi/epi_filesystem.cc
@@ -223,7 +223,7 @@ std::string GetDirectory(std::string_view path)
     {
         if (IsDirectorySeparator(path[p]))
         {
-            directory = path.substr(0, p);
+            directory = path.substr(0, p+1);
             break;
         }
     }


### PR DESCRIPTION
Fixes for a few things that have cropped up lately:
- Add check for __WINE_XINPUT_H (from MinGW's Xinput.h) being defined in libstem_gamepad to ensure various DIOBJECTDATAFORMAT structs are being populated when MSVC is not in use, as well as deconflict potential duplicate definitions of XINPUT_CAPABILITIES_EX
- Fix for A_JumpLiquid action ensuring the thing is actually on a liquid floor to satisfy the conditions
- Fix NO_RESPAWN DDFTHING special not being checked for on respawn
- Fix higher than desired vertical view range being allowed (this was allowing greater than 90 degrees which not only looks weird but interferes with swimming/ladder traversal
- Fix jittery view height changes when ascending from a crouch while standing in a flat with SINK_DEPTH
- Fix for EPI GetDirectory function
- Add hints to use laptop dedicated GPUs when applicable on Windows
- Update formatting for XGL node file names