### PR TITLE
Various accumulated fixes and updates

### DIFF
--- a/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
+++ b/libraries/libstem_gamepad/source/gamepad/Gamepad_windows_dinput.c
@@ -42,8 +42,8 @@
 #include <windows.h>
 #include <regstr.h>
 #include <dinput.h>
-#include <XInput.h>
-#include <Dbt.h>
+#include <xinput.h>
+#include <dbt.h>
 
 // The following code is from SDL2
 // detects gamepad device remove/attach events without having to poll multiple times per second
@@ -167,6 +167,7 @@ static void CheckDeviceNotification(DeviceNotificationData *data)
 
 #define INPUT_QUEUE_SIZE 32
 #define XINPUT_GAMEPAD_GUIDE 0x400
+
 typedef struct {
 	XINPUT_CAPABILITIES Capabilities;
 	WORD VendorId;
@@ -174,7 +175,7 @@ typedef struct {
 	WORD VersionNumber;
 	WORD unk1;
 	DWORD unk2;
-} XINPUT_CAPABILITIES_EX;
+} LIBSTEM_XINPUT_CAPABILITIES_EX;
 
 struct Gamepad_devicePrivate {
 	gamepad_bool isXInput;
@@ -205,7 +206,7 @@ static const char * xInputDeviceNames[4] = {
 };
 
 static DWORD (WINAPI * XInputGetState_proc)(DWORD dwUserIndex, XINPUT_STATE * pState) = NULL;
-static DWORD (WINAPI * XInputGetCapabilitiesEx_proc)(DWORD unk1, DWORD dwUserIndex, DWORD dwFlags, XINPUT_CAPABILITIES_EX * pCapabilities) = NULL;
+static DWORD (WINAPI * XInputGetCapabilitiesEx_proc)(DWORD unk1, DWORD dwUserIndex, DWORD dwFlags, LIBSTEM_XINPUT_CAPABILITIES_EX * pCapabilities) = NULL;
 
 static LPDIRECTINPUT directInputInterface;
 static gamepad_bool inited = gamepad_false;
@@ -224,7 +225,7 @@ void Gamepad_init() {
 		} else {
 			xInputAvailable = gamepad_true;
 			XInputGetState_proc = (DWORD (WINAPI *)(DWORD, XINPUT_STATE *)) GetProcAddress(module, "XInputGetState");
-			XInputGetCapabilitiesEx_proc = (DWORD (WINAPI *)(DWORD, DWORD, DWORD, XINPUT_CAPABILITIES_EX *)) GetProcAddress(module, (LPCSTR) 108);
+			XInputGetCapabilitiesEx_proc = (DWORD (WINAPI *)(DWORD, DWORD, DWORD, LIBSTEM_XINPUT_CAPABILITIES_EX *)) GetProcAddress(module, (LPCSTR) 108);
 		}
 		
 		module = LoadLibrary("DINPUT8.dll");
@@ -483,7 +484,7 @@ static BOOL CALLBACK enumHatsCallback(LPCDIDEVICEOBJECTINSTANCE instance, LPVOID
 	return DIENUM_CONTINUE;
 }
 
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined __WINE_XINPUT_H
 #ifndef DIDFT_OPTIONAL
 #define DIDFT_OPTIONAL      0x80000000
 #endif
@@ -839,7 +840,7 @@ static void removeDevice(unsigned int deviceIndex) {
 void Gamepad_detectDevices() {
 	HRESULT result;
 	DWORD xResult;
-	XINPUT_CAPABILITIES_EX capabilities_ex;
+	LIBSTEM_XINPUT_CAPABILITIES_EX capabilities_ex;
 	unsigned int playerIndex, deviceIndex;
 	
 	if (!inited) {

--- a/source_files/ddf/ddf_level.cc
+++ b/source_files/ddf/ddf_level.cc
@@ -96,7 +96,6 @@ static DDFSpecialFlags map_specials[] = {{"CHEATS", kMapFlagCheats, 0},
                                          {"AUTOAIM", kMapFlagAutoAim, 0},
                                          {"RESET_PLAYER", kMapFlagResetPlayer, 0},
                                          {"LIMIT_ZOOM", kMapFlagLimitZoom, 0},
-                                         {"WEAPON_KICK", kMapFlagKicking, 0},
 
                                          {nullptr, 0, 0}};
 

--- a/source_files/ddf/ddf_level.h
+++ b/source_files/ddf/ddf_level.h
@@ -81,7 +81,7 @@ enum MapFlag
     //kMapFlagExtras       = (1 << 13), // Legacy, no longer used
     kMapFlagLimitZoom    = (1 << 14), // Limit zoom to certain weapons
     //kMapFlagCrouching    = (1 << 15), // Unconditionally on
-    kMapFlagKicking      = (1 << 16), // Weapon recoil
+    //kMapFlagKicking      = (1 << 16), // Legacy, no longer used
     kMapFlagWeaponSwitch = (1 << 17),
     //kMapFlagPassMissile  = (1 << 18), // Legacy, no longer used
     kMapFlagTeamDamage   = (1 << 19),

--- a/source_files/ddf/ddf_thing.cc
+++ b/source_files/ddf/ddf_thing.cc
@@ -162,7 +162,6 @@ const DDFCommandList thing_commands[] = {
     DDF_FIELD("SIGHT_SLOPE", dummy_mobj, sight_slope_, DDFMainGetSlope),
     DDF_FIELD("SIGHT_ANGLE", dummy_mobj, sight_angle_, DDFMainGetAngle),
     DDF_FIELD("RIDE_FRICTION", dummy_mobj, ride_friction_, DDFMainGetFloat),
-    DDF_FIELD("BOBBING", dummy_mobj, bobbing_, DDFMainGetPercent),
     DDF_FIELD("IMMUNITY_CLASS", dummy_mobj, immunity_, DDFMainGetBitSet),
     DDF_FIELD("RESISTANCE_CLASS", dummy_mobj, resistance_, DDFMainGetBitSet),
     DDF_FIELD("RESISTANCE_MULTIPLY", dummy_mobj, resist_multiply_, DDFMainGetFloat),
@@ -2016,7 +2015,6 @@ void MapObjectDefinition::CopyDetail(MapObjectDefinition &src)
     // choke_damage
     choke_damage_ = src.choke_damage_;
 
-    bobbing_           = src.bobbing_;
     immunity_          = src.immunity_;
     resistance_        = src.resistance_;
     resist_multiply_   = src.resist_multiply_;
@@ -2149,7 +2147,6 @@ void MapObjectDefinition::Default()
 
     choke_damage_.Default(DamageClass::kDamageClassDefaultMobjChoke);
 
-    bobbing_           = 1.0f;
     immunity_          = 0;
     resistance_        = 0;
     resist_multiply_   = 0.4;

--- a/source_files/ddf/ddf_thing.h
+++ b/source_files/ddf/ddf_thing.h
@@ -807,9 +807,6 @@ class MapObjectDefinition
     int         gasp_start_;
     DamageClass choke_damage_;
 
-    // controls how much the player bobs when walking.
-    float bobbing_;
-
     // what attack classes we are immune/resistant to (usually none).
     BitSet immunity_;
     BitSet resistance_;

--- a/source_files/ddf/ddf_types.h
+++ b/source_files/ddf/ddf_types.h
@@ -477,8 +477,6 @@ class WeaponDefinition
     int            clip_size_[4];   // Amount of shots in a clip (if <= 1, non-clip weapon)
     bool           autofire_[4];    // If true, this is an automatic else it's semiauto
 
-    float kick_;                    // Amount of kick this weapon gives
-
     // range of states used
     std::vector<StateRange> state_grp_;
 
@@ -554,11 +552,6 @@ class WeaponDefinition
 
     // -AJA- 2007/11/12: clip is shared between 1st/2nd attacks.
     bool shared_clip_;
-
-    // controls for weapon bob (up & down) and sway (left & right).
-    // Given as percentages in DDF.
-    float bobbing_;
-    float swaying_;
 
     // -AJA- 2004/11/15: idle states (polish weapon, crack knuckles)
     int   idle_wait_;

--- a/source_files/ddf/ddf_weapon.cc
+++ b/source_files/ddf/ddf_weapon.cc
@@ -93,13 +93,10 @@ static const DDFCommandList weapon_commands[] = {
     DDF_FIELD("START_SOUND", dummy_weapon, start_, DDFMainLookupSound),
     DDF_FIELD("NOTHRUST", dummy_weapon, nothrust_, DDFMainGetBoolean),
     DDF_FIELD("FEEDBACK", dummy_weapon, feedback_, DDFMainGetBoolean),
-    DDF_FIELD("KICK", dummy_weapon, kick_, DDFMainGetFloat),
     DDF_FIELD("ZOOM_FACTOR", dummy_weapon, zoom_fov_, DDFWGetZoomFactor),
     DDF_FIELD("REFIRE_INACCURATE", dummy_weapon, refire_inacc_, DDFMainGetBoolean),
     DDF_FIELD("SHOW_CLIP", dummy_weapon, show_clip_, DDFMainGetBoolean),
     DDF_FIELD("SHARED_CLIP", dummy_weapon, shared_clip_, DDFMainGetBoolean),
-    DDF_FIELD("BOBBING", dummy_weapon, bobbing_, DDFMainGetPercent),
-    DDF_FIELD("SWAYING", dummy_weapon, swaying_, DDFMainGetPercent),
     DDF_FIELD("IDLE_WAIT", dummy_weapon, idle_wait_, DDFMainGetTime),
     DDF_FIELD("IDLE_CHANCE", dummy_weapon, idle_chance_, DDFMainGetPercent),
 
@@ -168,7 +165,6 @@ static const DDFActionCode weapon_actions[] = {{"NOTHING", nullptr, nullptr},
                                                {"REFIRE_TO", A_ReFireTo, DDFStateGetJump},
                                                {"NOFIRE", A_NoFire, nullptr},
                                                {"NOFIRE_RETURN", A_NoFireReturn, nullptr},
-                                               {"KICK", A_WeaponKick, DDFStateGetFloat},
                                                {"CHECKRELOAD", A_CheckReload, nullptr},
                                                {"PLAYSOUND", A_WeaponPlaySound, DDFStateGetSound},
                                                {"KILLSOUND", A_WeaponKillSound, nullptr},
@@ -729,8 +725,6 @@ void WeaponDefinition::CopyDetail(WeaponDefinition &src)
         flash_state_[ATK]   = src.flash_state_[ATK];
     }
 
-    kick_ = src.kick_;
-
     up_state_    = src.up_state_;
     down_state_  = src.down_state_;
     ready_state_ = src.ready_state_;
@@ -768,8 +762,6 @@ void WeaponDefinition::CopyDetail(WeaponDefinition &src)
     show_clip_    = src.show_clip_;
     shared_clip_  = src.shared_clip_;
 
-    bobbing_     = src.bobbing_;
-    swaying_     = src.swaying_;
     idle_wait_   = src.idle_wait_;
     idle_chance_ = src.idle_chance_;
 
@@ -805,8 +797,6 @@ void WeaponDefinition::Default(void)
     specials_[2] = (WeaponFlag)(kDefaultWeaponFlags & ~WeaponFlagSwitchAway);
     specials_[3] = (WeaponFlag)(kDefaultWeaponFlags & ~WeaponFlagSwitchAway);
 
-    kick_ = 0.0f;
-
     up_state_    = 0;
     down_state_  = 0;
     ready_state_ = 0;
@@ -841,8 +831,6 @@ void WeaponDefinition::Default(void)
     show_clip_    = false;
     shared_clip_  = false;
 
-    bobbing_     = 1.0f;
-    swaying_     = 1.0f;
     idle_wait_   = 15 * kTicRate;
     idle_chance_ = 0.12f;
 

--- a/source_files/edge/defaults.h
+++ b/source_files/edge/defaults.h
@@ -78,7 +78,6 @@
 
 // Gameplay Options
 #define EDGE_DEFAULT_AUTOAIM        (0)
-#define EDGE_DEFAULT_KICKING        (0)
 #define EDGE_DEFAULT_WEAPON_SWITCH  (1)
 #define EDGE_DEFAULT_MORE_BLOOD     (0)
 #define EDGE_DEFAULT_RES_RESPAWN    (1) // Resurrect Mode

--- a/source_files/edge/dm_defs.h
+++ b/source_files/edge/dm_defs.h
@@ -82,7 +82,6 @@ struct GameFlags
     bool cheats;
     bool limit_zoom;
 
-    bool kicking;
     bool weapon_switch;
     bool team_damage;
 };

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -118,7 +118,6 @@ GameFlags default_game_flags = {
     true,       // cheats
     false,      // limit_zoom
 
-    true,       // kicking
     true,       // weapon_switch
     false,      // team_damage
 };
@@ -322,7 +321,6 @@ static void SetGlobalVariables(void)
     CheckBooleanParameter("items_respawn", &global_flags.items_respawn, false);
     CheckBooleanParameter("monsters", &global_flags.no_monsters, true);
     CheckBooleanParameter("fast", &global_flags.fast_monsters, false);
-    CheckBooleanParameter("kick", &global_flags.kicking, false);
     CheckBooleanParameter("single_tics", &single_tics, false);
     CheckBooleanParameter("blood", &global_flags.more_blood, false);
     CheckBooleanParameter("cheats", &global_flags.cheats, false);

--- a/source_files/edge/e_player.cc
+++ b/source_files/edge/e_player.cc
@@ -179,8 +179,6 @@ void Player::Reborn()
 
     cheats_             = 0;
     refire_             = 0;
-    bob_factor_         = 0;
-    kick_offset_        = 0;
     zoom_field_of_view_ = 0;
     bonus_count_        = 0;
     damage_count_       = 0;

--- a/source_files/edge/e_player.h
+++ b/source_files/edge/e_player.h
@@ -142,7 +142,7 @@ class Player
     // the player thing moves on the 2D map.
     float actual_speed_;
 
-    // Determine POV, including viewpoint bobbing during movement.
+    // Determine POV
     // Focal origin above r.z
     // will be kFloatUnused until the first think.
     float view_z_;
@@ -157,13 +157,6 @@ class Player
 
     // standard viewheight, usually 75% of height.
     float standard_view_height_;
-
-    // bounded/scaled total momentum.
-    float bob_factor_;
-    int   erraticism_bob_ticker_ = 0; // Erraticism bob timer to prevent weapon bob jumps
-
-    // Kick offset for vertangle (in mobj_t)
-    float kick_offset_;
 
     // when > 0, the player has activated zoom
     int zoom_field_of_view_;

--- a/source_files/edge/g_game.cc
+++ b/source_files/edge/g_game.cc
@@ -169,7 +169,6 @@ void LoadLevel_Bits(void)
     HandleLevelFlag(&level_flags.enemies_respawn, kMapFlagRespawn);
     HandleLevelFlag(&level_flags.enemy_respawn_mode, kMapFlagResRespawn);
     HandleLevelFlag(&level_flags.limit_zoom, kMapFlagLimitZoom);
-    HandleLevelFlag(&level_flags.kicking, kMapFlagKicking);
     HandleLevelFlag(&level_flags.weapon_switch, kMapFlagWeaponSwitch);
     HandleLevelFlag(&level_flags.team_damage, kMapFlagTeamDamage);
 

--- a/source_files/edge/i_video.cc
+++ b/source_files/edge/i_video.cc
@@ -18,6 +18,13 @@
 
 #include "i_video.h"
 
+// Set hints to select dedicated GPU in laptop iGPU/dGPU setups
+#ifdef _WIN32
+#include "epi_windows.h"
+extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+extern "C" __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+#endif
+
 #include "edge_profiling.h"
 #include "epi_str_compare.h"
 #include "epi_str_util.h"

--- a/source_files/edge/m_misc.cc
+++ b/source_files/edge/m_misc.cc
@@ -90,7 +90,6 @@ static ConfigurationDefault defaults[] = {
 
     // -KM- 1998/07/21 Save the blood setting
     {kConfigBoolean, "blood", &global_flags.more_blood, EDGE_DEFAULT_MORE_BLOOD},
-    {kConfigBoolean, "weaponkick", &global_flags.kicking, EDGE_DEFAULT_KICKING},
     {kConfigBoolean, "weaponswitch", &global_flags.weapon_switch, EDGE_DEFAULT_WEAPON_SWITCH},
     {kConfigInteger, "smoothing", &image_smoothing, EDGE_DEFAULT_USE_SMOOTHING},
 

--- a/source_files/edge/p_action.cc
+++ b/source_files/edge/p_action.cc
@@ -57,7 +57,7 @@
 #include "r_state.h"
 #include "s_sound.h"
 
-
+extern bool P_IsThingOnLiquidFloor(MapObject *thing);
 extern FlatDefinition *P_GetThingFlatDef(MapObject *thing);
 
 static int AttackSfxCat(const MapObject *mo)
@@ -3390,9 +3390,7 @@ void A_JumpLiquid(MapObject *mo)
     //
     // Note: nothing to do with monsters physically jumping.
 
-    FlatDefinition *flat = P_GetThingFlatDef(mo);
-
-    if (!flat || !flat->impactobject_) // Are we touching a liquid floor?
+    if (!P_IsThingOnLiquidFloor(mo)) // Are we touching a liquid floor?
     {
         return;
     }

--- a/source_files/edge/p_action.h
+++ b/source_files/edge/p_action.h
@@ -60,7 +60,6 @@ void A_SetCrosshair(MapObject *mo);
 void A_TargetJump(MapObject *mo);
 void A_FriendJump(MapObject *mo);
 void A_GunFlash(MapObject *mo);
-void A_WeaponKick(MapObject *mo);
 void A_WeaponUnzoom(MapObject *mo);
 void A_WeaponBecome(MapObject *mo);
 

--- a/source_files/edge/p_mobj.cc
+++ b/source_files/edge/p_mobj.cc
@@ -1434,6 +1434,10 @@ static void P_MobjThinker(MapObject *mobj)
         if (!level_flags.enemies_respawn)
             return;
 
+        // check for NO_RESPAWN flag
+        if (mobj->extended_flags_ & kExtendedFlagNoRespawn)
+            return;
+
         mobj->move_count_++;
 
         //
@@ -1896,6 +1900,28 @@ void SpawnBlood(float x, float y, float z, float damage, BAMAngle angle, const M
 FlatDefinition *P_GetThingFlatDef(MapObject *thing)
 {
     return flatdefs.Find(thing->subsector_->sector->floor.image->name_.c_str());
+}
+
+//---------------------------------------------------------------------------
+//
+// FUNC P_IsThingOnLiquidFloor
+//
+//---------------------------------------------------------------------------
+
+// For now, this will mean any floor with an "impact object" that exists when something
+// hits it; this is usually a splash but can be any debris
+
+bool P_IsThingOnLiquidFloor(MapObject *thing)
+{
+    if (thing->flags_ & kMapObjectFlagFloat)
+        return false;
+ 
+    if (thing->z > thing->floor_z_) //are we actually touching the floor
+        return false;
+
+    FlatDefinition *liquid_check = P_GetThingFlatDef(thing);
+
+    return (liquid_check && liquid_check->impactobject_);
 }
 
 //---------------------------------------------------------------------------

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -2499,7 +2499,7 @@ void LevelSetup(void)
 
     // This needs to be cached somewhere, but it will work here while developing - Dasho
     uint64_t udmf_hash = epi::StringHash64(udmf_string);
-    node_file = epi::PathAppend("cache", epi::StringFormat("%s-%lu.xgl", current_map->name_.c_str(), udmf_hash));
+    node_file = epi::PathAppend("cache", epi::StringFormat("%s-%llu.xgl", current_map->name_.c_str(), udmf_hash));
 
     // get lump for XGL3 nodes from an XWA file
     // shouldn't happen (as during startup we checked for or built these)

--- a/source_files/edge/p_weapon.h
+++ b/source_files/edge/p_weapon.h
@@ -58,6 +58,7 @@ struct PlayerSprite
 
     // screen position values (0 is normal)
     float screen_x, screen_y;
+    float old_screen_x, old_screen_y;  
 
     // translucency values
     float visibility;

--- a/source_files/edge/r_render.cc
+++ b/source_files/edge/r_render.cc
@@ -1759,8 +1759,6 @@ static void InitializeCamera(MapObject *mo, bool full_height, float expand_w)
 
     if (mo->player_)
     {
-        view_vertical_angle += epi::BAMFromATan(mo->player_->kick_offset_);
-
         // No heads above the ceiling
         if (view_z > mo->player_->map_object_->ceiling_z_ - 2)
             view_z = mo->player_->map_object_->ceiling_z_ - 2;

--- a/source_files/edge/r_things.cc
+++ b/source_files/edge/r_things.cc
@@ -188,10 +188,23 @@ static void RenderPSprite(PlayerSprite *psp, int which, Player *player, RegionPr
     float coord_W = 320.0f * widescreen_view_width_multiplier;
     float coord_H = 200.0f;
 
-    float tx1 = (coord_W - w) / 2.0 + psp->screen_x - image->ScaledOffsetX();
+    float psp_x, psp_y;
+
+    if (uncapped_frames.d_ && !paused)
+    {
+        psp_x = glm_lerp(psp->old_screen_x, psp->screen_x, fractional_tic);
+        psp_y = glm_lerp(psp->old_screen_y, psp->screen_y, fractional_tic);
+    }
+    else
+    {
+        psp_x = psp->screen_x;
+        psp_y = psp->screen_y;
+    }
+
+    float tx1 = (coord_W - w) / 2.0 + psp_x - image->ScaledOffsetX();
     float tx2 = tx1 + w;
 
-    float ty1 = -psp->screen_y + image->ScaledOffsetY() - ((h - image->ScaledHeightActual()) * 0.5f);
+    float ty1 = -psp_y + image->ScaledOffsetY() - ((h - image->ScaledHeightActual()) * 0.5f);
 
     float ty2 = ty1 + h;
 

--- a/source_files/edge/w_epk.cc
+++ b/source_files/edge/w_epk.cc
@@ -429,7 +429,7 @@ void ProcessPackContents()
                 std::string udmf_string = udmf_file->ReadAsString();
                 delete udmf_file;
                 udmf_hash = epi::StringHash64(udmf_string);
-                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%lu.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
+                std::string node_file = epi::PathAppend("cache", epi::StringFormat("%s-%llu.xgl",epi::GetStem(entry.pack_path_).c_str(), udmf_hash));
                 if (!epi::FileExists(node_file))
                     ajbsp::BuildLevel(epi::GetStem(entry.pack_path_), node_file, udmf_string);
             }

--- a/source_files/epi/epi_filesystem.cc
+++ b/source_files/epi/epi_filesystem.cc
@@ -223,7 +223,7 @@ std::string GetDirectory(std::string_view path)
     {
         if (IsDirectorySeparator(path[p]))
         {
-            directory = path.substr(0, p);
+            directory = path.substr(0, p+1);
             break;
         }
     }


### PR DESCRIPTION
- Add check for __WINE_XINPUT_H (from MinGW's Xinput.h) being defined in libstem_gamepad to ensure various DIOBJECTDATAFORMAT structs are being populated when MSVC is not in use, as well as deconflict potential duplicate definitions of XINPUT_CAPABILITIES_EX
- Fix for A_JumpLiquid action ensuring the thing is actually on a liquid floor to satisfy the conditions
- Fix NO_RESPAWN DDFTHING special not being checked for on respawn
- Fix higher than desired vertical view range being allowed (this was allowing greater than 90 degrees which not only looks weird but interferes with swimming/ladder traversal
- Fix jittery view height changes when ascending from a crouch while standing in a flat with SINK_DEPTH
- Fix for EPI GetDirectory function
- Add hints to use laptop dedicated GPUs when applicable on Windows
- Update formatting for XGL node file names
- Remove view bobbing
- Remove weapon bobbing, swaying, and kick